### PR TITLE
Disable format on save temporarily

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "files.eol": "\n",
     "typescript.tsdk": "node_modules/typescript/lib"


### PR DESCRIPTION
The format on save functionality currently causes a heavy amount of modifications due to the files not being formatted properly.

A full clean-up will be done in #193 in a separate milestone.