### PR TITLE
Fix import note type

### DIFF
--- a/src/becca/entities/rows.ts
+++ b/src/becca/entities/rows.ts
@@ -91,7 +91,8 @@ export interface BranchRow {
  * end user. Those types should be used only for checking against, they are
  * not for direct use.
  */
-export type NoteType = ("file" | "image" | "search" | "noteMap" | "launcher" | "doc" | "contentWidget" | "text" | "relationMap" | "render" | "canvas" | "mermaid" | "book" | "webView" | "code");
+export const ALLOWED_NOTE_TYPES = [ "file", "image", "search", "noteMap", "launcher", "doc", "contentWidget", "text", "relationMap", "render", "canvas", "mermaid", "book", "webView", "code" ] as const;
+export type NoteType = typeof ALLOWED_NOTE_TYPES[number];
 
 export interface NoteRow {
     noteId: string;

--- a/src/becca/entities/rows.ts
+++ b/src/becca/entities/rows.ts
@@ -107,5 +107,5 @@ export interface NoteRow {
     dateModified: string;
     utcDateCreated: string;
     utcDateModified: string;
-    content?: string;
+    content?: string | Buffer;
 }

--- a/src/services/import/zip.ts
+++ b/src/services/import/zip.ts
@@ -500,10 +500,6 @@ async function importZip(taskContext: TaskContext, fileBuffer: Buffer, importRoo
             }
         }
         else {
-            if (typeof content !== "string") {
-                throw new Error("Incorrect content type.");
-            }
-
             ({note} = noteService.createNewNote({
                 parentNoteId: parentNoteId,
                 title: noteTitle || "",

--- a/src/services/import/zip.ts
+++ b/src/services/import/zip.ts
@@ -231,7 +231,7 @@ async function importZip(taskContext: TaskContext, fileBuffer: Buffer, importRoo
         if (!parentNoteId) {
             throw new Error("Missing parent note ID.");
         }
-        
+
         const {note} = noteService.createNewNote({
             parentNoteId: parentNoteId,
             title: noteTitle || "",
@@ -462,14 +462,13 @@ async function importZip(taskContext: TaskContext, fileBuffer: Buffer, importRoo
         }
 
         let type = resolveNoteType(noteMeta?.type);
-        console.log("Resolved note type is ", noteMeta?.type, resolveNoteType(noteMeta?.type));
 
         if (type !== 'file' && type !== 'image') {
             content = content.toString("utf-8");
         }
 
         const noteTitle = utils.getNoteTitle(filePath, taskContext.data?.replaceUnderscoresWithSpaces || false, noteMeta);
-        
+
         content = processNoteContent(noteMeta, type, mime, content, noteTitle || "", filePath);
 
         let note = becca.getNote(noteId);

--- a/src/services/import/zip.ts
+++ b/src/services/import/zip.ts
@@ -20,7 +20,7 @@ import BNote = require('../../becca/entities/bnote');
 import NoteMeta = require('../meta/note_meta');
 import AttributeMeta = require('../meta/attribute_meta');
 import { Stream } from 'stream';
-import { NoteType } from '../../becca/entities/rows';
+import { ALLOWED_NOTE_TYPES, NoteType } from '../../becca/entities/rows';
 
 interface MetaFile {
     files: NoteMeta[]
@@ -231,7 +231,7 @@ async function importZip(taskContext: TaskContext, fileBuffer: Buffer, importRoo
         if (!parentNoteId) {
             throw new Error("Missing parent note ID.");
         }
-
+        
         const {note} = noteService.createNewNote({
             parentNoteId: parentNoteId,
             title: noteTitle || "",
@@ -462,13 +462,14 @@ async function importZip(taskContext: TaskContext, fileBuffer: Buffer, importRoo
         }
 
         let type = resolveNoteType(noteMeta?.type);
+        console.log("Resolved note type is ", noteMeta?.type, resolveNoteType(noteMeta?.type));
 
         if (type !== 'file' && type !== 'image') {
             content = content.toString("utf-8");
         }
 
         const noteTitle = utils.getNoteTitle(filePath, taskContext.data?.replaceUnderscoresWithSpaces || false, noteMeta);
-
+        
         content = processNoteContent(noteMeta, type, mime, content, noteTitle || "", filePath);
 
         let note = becca.getNote(noteId);
@@ -653,7 +654,11 @@ function resolveNoteType(type: string | undefined): NoteType {
         return 'webView';
     }
 
-    return "text";
+    if (type && (ALLOWED_NOTE_TYPES as readonly string[]).includes(type)) {
+        return type as NoteType;
+    } else {
+        return "text";
+    }
 }
 
 export = {

--- a/src/services/note-interface.ts
+++ b/src/services/note-interface.ts
@@ -7,7 +7,7 @@ export interface NoteParams {
     parentNoteId: string;
     templateNoteId?: string;
     title: string;
-    content: string;
+    content: string | Buffer;
     /** text, code, file, image, search, book, relationMap, canvas, webView */
     type: NoteType;
     /** default value is derived from default mimes for type */

--- a/src/services/search/expressions/note_content_fulltext.ts
+++ b/src/services/search/expressions/note_content_fulltext.ts
@@ -74,7 +74,7 @@ class NoteContentFulltextExp extends Expression {
         }
 
         if (isProtected) {
-            if (!protectedSessionService.isProtectedSessionAvailable() || !content) {
+            if (!protectedSessionService.isProtectedSessionAvailable() || !content || typeof content !== "string") {
                 return;
             }
 
@@ -86,7 +86,7 @@ class NoteContentFulltextExp extends Expression {
             }
         }
 
-        if (!content) {
+        if (!content || typeof content !== "string") {
             return;
         }
 


### PR DESCRIPTION
Fixes TriliumNext/trilium#5059 , a regression caused by the backport to TypeScript where the note type was not properly preserved.