### PR TITLE
Fix build scripts & add CI for running them

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 node_modules
 
 src/**/*.ts
+!src/services/asset_path.ts

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,8 +1,6 @@
 name: Dev
 on:
   push:
-    branches_ignore:
-      - 'feature/fix_build_scripts'
 jobs:
   build_docker:
     name: Build Docker image

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,8 @@
 name: Dev
 on:
   push:
+    branches_ignore:
+      - 'feature/fix_build_scripts'
 jobs:
   build_docker:
     name: Build Docker image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,13 @@ jobs:
     name: Build Windows x86_64
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Wine
+        run: |
+          sudo dpkg --add-architecture i386
+          wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+          sudo add-apt-repository ppa:cybermax-dexter/sdl2-backport
+          sudo apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu $(lsb_release -cs) main"
+          sudo apt install --install-recommends winehq-stable
       - uses: actions/checkout@v4
       - name: Set up node & dependencies
         uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'feature/fix_build_scripts'
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,22 @@ jobs:
         with:
           name: trilium_amd64.deb
           path: dist/trilium_*.deb
+  build_linux_server-x64:
+    name: Build Linux Server x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up node & dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - run: ./bin/build-server.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trilium-linux-x64-server-x64.tar.xz
+          path: dist/trilium-linux-x64-server-*.tar.xz
   build_docker:
     name: Build Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,24 @@ jobs:
       - run: ./bin/build-server.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: trilium-linux-x64-server-x64.tar.xz
+          name: trilium-linux-x64-server.tar.xz
           path: dist/trilium-linux-x64-server-*.tar.xz
+  build_windows-x64:
+    name: Build Windows x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up node & dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - run: ./bin/build-win-x64.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trilium-windows-x64.zip
+          path: dist/trilium-windows-x64-*.zip
   build_docker:
     name: Build Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,27 @@ on:
   push:
     branches:
       - 'develop'
+      - 'feature/fix_build_scripts'
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 jobs:
+  build_macos_64:
+    name: Build macOS x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up node & dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - run: ./bin/build-mac-x64.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trilium-mac-x64.zip
+          path: dist/trilium-mac-x64*.zip
   build_docker:
     name: Build Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 jobs:
-  build_macos_64:
+  build_darwin-x64:
     name: Build macOS x86_64
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +24,26 @@ jobs:
         with:
           name: trilium-mac-x64.zip
           path: dist/trilium-mac-x64*.zip
+  build_linux-x64:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up node & dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - run: ./bin/build-linux-x64.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trilium-linux-x64.tar.xz
+          path: dist/trilium-linux-x64-*.tar.xz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trilium_amd64.deb
+          path: dist/trilium_*.deb
   build_docker:
     name: Build Docker image
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN set -x \
     && npm prune --omit=dev \
     && cp src/public/app/share.js src/public/app-dist/. \
     && cp -r src/public/app/doc_notes src/public/app-dist/. \
-    && rm -rf src/public/app
+    && rm -rf src/public/app \
+    && rm src/services/asset_path.ts
 
 # Some setup tools need to be kept
 RUN apk add --no-cache su-exec shadow

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-backend-docs": "rm -rf ./docs/backend_api && ./node_modules/.bin/jsdoc -c jsdoc-conf.json -d ./docs/backend_api src/becca/entities/*.js src/services/backend_script_api.js src/services/sql.js",
     "build-frontend-docs": "rm -rf ./docs/frontend_api && ./node_modules/.bin/jsdoc -c jsdoc-conf.json -d ./docs/frontend_api src/public/app/entities/*.js src/public/app/services/frontend_script_api.js src/public/app/widgets/basic_widget.js src/public/app/widgets/note_context_aware_widget.js src/public/app/widgets/right_panel_widget.js",
     "build-docs": "npm run build-backend-docs && npm run build-frontend-docs",
-    "webpack": "webpack -c webpack.config.js",
+    "webpack": "webpack -c webpack.config.ts",
     "test-jasmine": "TRILIUM_DATA_DIR=~/trilium/data-test jasmine",
     "test-es6": "node -r esm spec-es6/attribute_parser.spec.js ",
     "test": "npm run test-jasmine && npm run test-es6",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,5 +1,5 @@
-const path = require('path');
-const assetPath = require('./src/services/asset_path');
+import path = require('path');
+import assetPath = require('./src/services/asset_path');
 
 module.exports = {
     mode: 'production',


### PR DESCRIPTION
Adapts the existing build scripts to be able to run with the TypeScript integration, and adds GitHub Actions to build these versions automatically whenever a PR is merged in `develop`.

Here's how it looks like:

![image](https://github.com/user-attachments/assets/dcc8d4b7-72b4-4791-85ea-a65352443d4c)

The artifacts can be downloaded by scrolling all the way down in the [Run summary page](https://github.com/TriliumNext/Notes/actions/runs/9922994246):

![image](https://github.com/user-attachments/assets/8ab1dd5b-844a-49fe-9243-22e2aa292648)
