### PR TITLE
Check for empty string to avoid error.

### DIFF
--- a/src/public/app/widgets/note_title.js
+++ b/src/public/app/widgets/note_title.js
@@ -38,8 +38,8 @@ export default class NoteTitleWidget extends NoteContextAwareWidget {
 
             protectedSessionHolder.touchProtectedSessionIfNecessary(this.note);
 
-            // Allowing "" and " " will trigger SQL errors when title is deleted
-            if ( title !== "" && title != " ")
+            // Regex is making sure the title is not full of spaces
+            if ( title.match("^(?!\\s*$)"))
                 await server.put(`notes/${this.noteId}/title`, {title}, this.componentId);
         });
 

--- a/src/public/app/widgets/note_title.js
+++ b/src/public/app/widgets/note_title.js
@@ -38,7 +38,9 @@ export default class NoteTitleWidget extends NoteContextAwareWidget {
 
             protectedSessionHolder.touchProtectedSessionIfNecessary(this.note);
 
-            await server.put(`notes/${this.noteId}/title`, {title}, this.componentId);
+            // Allowing "" and " " will trigger SQL errors when title is deleted
+            if ( title !== "" && title != " ")
+                await server.put(`notes/${this.noteId}/title`, {title}, this.componentId);
         });
 
         this.deleteNoteOnEscape = false;

--- a/src/routes/api/notes.ts
+++ b/src/routes/api/notes.ts
@@ -138,9 +138,6 @@ function changeTitle(req: Request) {
 
     const note = becca.getNoteOrThrow(noteId);
 
-    if ( title !== " " )
-        return note
-
     if (!note.isContentAvailable()) {
         throw new ValidationError(`Note '${noteId}' is not available for change`);
     }

--- a/src/routes/api/notes.ts
+++ b/src/routes/api/notes.ts
@@ -138,6 +138,9 @@ function changeTitle(req: Request) {
 
     const note = becca.getNoteOrThrow(noteId);
 
+    if ( title !== " " )
+        return note
+
     if (!note.isContentAvailable()) {
         throw new ValidationError(`Note '${noteId}' is not available for change`);
     }


### PR DESCRIPTION
Proposed fix for issue #204

Added a RegEx check before the API call to ensure that empty strings or strings with a single space don't make it to the backend.