### PR TITLE
server: Fix regression in uploading images

### DIFF
--- a/src/becca/entities/bnote.ts
+++ b/src/becca/entities/bnote.ts
@@ -1644,10 +1644,7 @@ class BNote extends AbstractBeccaEntity<BNote> {
             position
         });
 
-        if (!content) {
-            throw new Error("Attempted to save an attachment with no content.");
-        }
-
+        content = content || "";
         attachment.setContent(content, {forceSave: true});
 
         return attachment;


### PR DESCRIPTION
The attachment is first saved with no content while the image is being asynchronously resized. On our side we had a guard condition fail if the content was empty, whereas the original implementation was simply using an empty string instead.

Closes TriliumNext/trilium#5060 .