### PR TITLE
left_pane_toggle in mobile layout & left bar font 1em

### DIFF
--- a/src/public/app/layouts/desktop_layout.js
+++ b/src/public/app/layouts/desktop_layout.js
@@ -96,7 +96,7 @@ export default class DesktopLayout {
                 .css("width", "53px")
                 .child(new GlobalMenuWidget())
                 .child(new LauncherContainer())
-                .child(new LeftPaneToggleWidget())
+                .child(new LeftPaneToggleWidget(false))
             )
             .child(new LeftPaneContainer()
                 .child(new QuickSearchWidget())

--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -23,6 +23,8 @@ import LauncherContainer from "../widgets/containers/launcher_container.js";
 import RootContainer from "../widgets/containers/root_container.js";
 import SharedInfoWidget from "../widgets/shared_info.js";
 import PromotedAttributesWidget from "../widgets/ribbon_widgets/promoted_attributes.js";
+import LeftPaneToggleWidget from "../widgets/buttons/left_pane_toggle.js";
+import LeftPaneContainer from "../widgets/containers/left_pane_container.js";
 
 const MOBILE_CSS = `
 <style>
@@ -58,7 +60,7 @@ const FANCYTREE_CSS = `
     margin-top: 0px;
     overflow-y: auto;
     contain: content;
-    padding-left: 10px;
+    padding-left: 4px;
 }
 
 .fancytree-custom-icon {
@@ -66,12 +68,12 @@ const FANCYTREE_CSS = `
 }
 
 .fancytree-title {
-    font-size: 1.5em;
-    margin-left: 0.6em !important;
+    font-size: 1em;
+    margin-left: 0.4em !important;
 }
 
 .fancytree-node {
-    padding: 5px;
+    padding: 4px;
 }
 
 .fancytree-node .fancytree-expander:before {
@@ -119,10 +121,13 @@ export default class MobileLayout {
                 .css("width", "53px")
                 .child(new GlobalMenuWidget())
                 .child(new LauncherContainer())
+                .child(new LeftPaneToggleWidget(true))
             )
             .child(new FlexContainer("row")
                 .filling()
-                .child(new ScreenContainer("tree", 'column')
+                .child(
+                    new LeftPaneContainer()
+                    .child(new ScreenContainer("tree", 'column'))
                     .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-5 col-md-4 col-lg-3 col-xl-3")
                     .css("max-height", "100%")
                     .css('padding-left', "0")

--- a/src/public/app/services/resizer.js
+++ b/src/public/app/services/resizer.js
@@ -3,7 +3,7 @@ import options from "./options.js";
 let leftInstance;
 let rightInstance;
 
-function setupLeftPaneResizer(leftPaneVisible) {
+function setupLeftPaneResizer(leftPaneVisible, isMobile) {
     if (leftInstance) {
         leftInstance.destroy();
         leftInstance = null;
@@ -22,7 +22,7 @@ function setupLeftPaneResizer(leftPaneVisible) {
         leftPaneWidth = 5;
     }
 
-    if (leftPaneVisible) {
+    if (leftPaneVisible && !isMobile) {
         leftInstance = Split(['#left-pane', '#rest-pane'], {
             sizes: [leftPaneWidth, 100 - leftPaneWidth],
             gutterSize: 5,

--- a/src/public/app/widgets/buttons/left_pane_toggle.js
+++ b/src/public/app/widgets/buttons/left_pane_toggle.js
@@ -3,9 +3,9 @@ import splitService from "../../services/resizer.js";
 import CommandButtonWidget from "./command_button.js";
 
 export default class LeftPaneToggleWidget extends CommandButtonWidget {
-    constructor() {
+    constructor(isMobile) {
         super();
-
+        this.isMobile = isMobile;
         this.class("launcher-button");
 
         this.settings.icon = () => options.is('leftPaneVisible')
@@ -24,7 +24,7 @@ export default class LeftPaneToggleWidget extends CommandButtonWidget {
     refreshIcon() {
         super.refreshIcon();
 
-        splitService.setupLeftPaneResizer(options.is('leftPaneVisible'));
+        splitService.setupLeftPaneResizer(options.is('leftPaneVisible'), this.isMobile);
     }
 
     entitiesReloadedEvent({loadResults}) {


### PR DESCRIPTION
#276 #72 

Summary:
- reuse Desktop left_pane_toggle widget
- in order to do so, I added a isMobile flag to the `LeftPaneToggleWidget` so that we won't trigger the Split code (present in Desktop)
- reduced the font size from 1.5em to 1em for the left bar. imo it is unecessarily large for mobile devices (tested it on my tablet Samsung Tablet as well, now it is much better, also less text get cropped out. what do you think? I think the main goal would be reducing real estate inefficiency on mobile)