### PR TITLE
docs: Add Dockerhub link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To use TriliumNext on a mobile device:
 
 ### Server
 
-To install TriliumNext on your own server (including via Docker) follow [the server installation docs](https://triliumnext.github.io/Docs/Wiki/server-installation).
+To install TriliumNext on your own server (including via Docker from [Dockerhub](https://hub.docker.com/r/triliumnext/notes)) follow [the server installation docs](https://triliumnext.github.io/Docs/Wiki/server-installation).
 
 ## 📝 Documentation
 


### PR DESCRIPTION
The link to the official Docker images is hidden a bit deep inside the documentation, and I think it would make sense to establish the link directly from the README. It's the first I look on projects where I can find related Docker images.