### PR TITLE
Fix ARM container builds

### DIFF
--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -1,148 +1,155 @@
 on:
-    push:
-      branches:
-        - "develop"
-        - "feature/update**"
-        - "feature/server_esm**"
-      paths-ignore:
-        - "docs/**"
-        - "bin/**"
-      tags:
-        - "v*"
-    workflow_dispatch:  
+  push:
+    branches:
+      - "develop"
+      - "feature/update**"
+      - "feature/server_esm**"
+    paths-ignore:
+      - "docs/**"
+      - "bin/**"
+    tags:
+      - "v*"
+  workflow_dispatch:  
 
 env:
-    GHCR_REGISTRY: ghcr.io
-    DOCKERHUB_REGISTRY: docker.io
-    IMAGE_NAME: ${{ github.repository }}
-    TEST_TAG: triliumnext/notes:test
-    PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+  GHCR_REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
+  IMAGE_NAME: ${{ github.repository }}
+  TEST_TAG: triliumnext/notes:test
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm64/v8
 
 jobs:
-    test_docker:
-        name: Check Docker build
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout the repository
-              uses: actions/checkout@v4
+  test_docker:
+      name: Check Docker build
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout the repository
+            uses: actions/checkout@v4
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v3
 
-            - name: Set up node & dependencies
-              uses: actions/setup-node@v4
-              with:
-                node-version: 20
-                cache: "npm"
-            
-            - run: npm ci
-            
-            - name: Run the TypeScript build
-              run: npx tsc
-            
-            - name: Create server-package.json
-              run: cat package.json | grep -v electron > server-package.json
-
-            - name: Build and export to Docker
-              uses: docker/build-push-action@v6
-              with:
-                context: .
-                load: true
-                tags: ${{ env.TEST_TAG }}
-                cache-from: type=gha
-                cache-to: type=gha,mode=max
-
-            - name: Run the container in the background
-              run: docker run -d --rm --name trilium_local ${{ env.TEST_TAG }}
-
-            - name: Wait for the healthchecks to pass
-              uses: stringbean/docker-healthcheck-action@v1
-              with:
-                container: trilium_local
-                wait-time: 50
-                require-status: running
-                require-healthy: true
-
-    build_docker:
-        name: Build Docker images
-        runs-on: ubuntu-latest
-        needs:
-            - test_docker
-        permissions:
-          contents: read
-          packages: write
-          attestations: write
-          id-token: write
-        steps:                        
-          - uses: actions/checkout@v4
-          - name: Set up QEMU
-            uses: docker/setup-qemu-action@v3
-          - name: Extract metadata (tags, labels) for GHCR image
-            id: ghcr-meta
-            uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-            with:
-              images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
-              tags: 
-          - name: Extract metadata (tags, labels) for DockerHub image
-            id: dh-meta
-            uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-            with:
-              images: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
           - name: Set up node & dependencies
             uses: actions/setup-node@v4
             with:
               node-version: 20
               cache: "npm"
+          
           - run: npm ci
+          
           - name: Run the TypeScript build
             run: npx tsc
+          
           - name: Create server-package.json
             run: cat package.json | grep -v electron > server-package.json
-          - name: Log in to the GHCR container registry
-            uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-            with:
-              registry: ${{ env.GHCR_REGISTRY }}
-              username: ${{ github.actor }}
-              password: ${{ secrets.GITHUB_TOKEN }}
-          - uses: docker/setup-buildx-action@v3
-          - name: Build and push container image to GHCR
+
+          - name: Build and export to Docker
             uses: docker/build-push-action@v6
-            id: ghcr-push
             with:
               context: .
-              platforms: ${{ env.PLATFORMS }}
-              push: true              
-              tags: ${{ steps.ghcr-meta.outputs.tags }}
-              labels: ${{ steps.ghcr-meta.outputs.labels }}
+              load: true
+              tags: ${{ env.TEST_TAG }}
               cache-from: type=gha
               cache-to: type=gha,mode=max
-          - name: Generate and push artifact attestation to GHCR
-            uses: actions/attest-build-provenance@v1
+
+          - name: Run the container in the background
+            run: docker run -d --rm --name trilium_local ${{ env.TEST_TAG }}
+
+          - name: Wait for the healthchecks to pass
+            uses: stringbean/docker-healthcheck-action@v1
             with:
-              subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME}}
-              subject-digest: ${{ steps.ghcr-push.outputs.digest }}
-              push-to-registry: true
-          - name: Log in to the DockerHub container registry
-            uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-            with:
-              registry: ${{ env.DOCKERHUB_REGISTRY }}
-              username: ${{ secrets.DOCKERHUB_USERNAME }}
-              password: ${{ secrets.DOCKERHUB_TOKEN }}
-          - name: Build and push image to DockerHub
-            uses: docker/build-push-action@v6
-            id: dh-push
-            with:
-              context: .
-              platforms: ${{ env.PLATFORMS }}
-              push: true
-              tags: ${{ steps.dh-meta.outputs.tags }}
-              labels: ${{ steps.dh-meta.outputs.labels }}
-              cache-from: type=gha
-              cache-to: type=gha,mode=max
-          - name: Generate and push artifact attestation to DockerHub
-            uses: actions/attest-build-provenance@v1
-            with:
-              subject-name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME}}
-              subject-digest: ${{ steps.dh-push.outputs.digest }}
-              push-to-registry: true
-    
+              container: trilium_local
+              wait-time: 50
+              require-status: running
+              require-healthy: true
+
+  build_docker:
+      name: Build Docker images
+      runs-on: ubuntu-latest
+      needs:
+          - test_docker
+      permissions:
+        contents: read
+        packages: write
+        attestations: write
+        id-token: write
+      strategy:
+        matrix:
+          architecture: [linux/amd64, linux/arm64, linux/arm/v7, linux/arm64/v8]
+      steps:                        
+        - uses: actions/checkout@v4
+        - name: Extract metadata (tags, labels) for GHCR image
+          id: ghcr-meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=sha
+        - name: Extract metadata (tags, labels) for DockerHub image
+          id: dh-meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=sha
+        - name: Set up node & dependencies
+          uses: actions/setup-node@v4
+          with:
+            node-version: 20
+            cache: "npm"
+        - run: npm ci
+        - name: Run the TypeScript build
+          run: npx tsc
+        - name: Create server-package.json
+          run: cat package.json | grep -v electron > server-package.json
+        - name: Log in to the GHCR container registry
+          uses: docker/login-action@v2
+          with:
+            registry: ${{ env.GHCR_REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - uses: docker/setup-buildx-action@v3
+        - name: Build and push container image to GHCR
+          uses: docker/build-push-action@v6
+          id: ghcr-push
+          with:
+            context: .
+            platforms: ${{ matrix.architecture }}
+            push: true              
+            tags: ${{ steps.ghcr-meta.outputs.tags }}
+            labels: ${{ steps.ghcr-meta.outputs.labels }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+        - name: Generate and push artifact attestation to GHCR
+          uses: actions/attest-build-provenance@v1
+          with:
+            subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME}}
+            subject-digest: ${{ steps.ghcr-push.outputs.digest }}
+            push-to-registry: true
+        - name: Log in to the DockerHub container registry
+          uses: docker/login-action@v2
+          with:
+            registry: ${{ env.DOCKERHUB_REGISTRY }}
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+        - name: Build and push image to DockerHub
+          uses: docker/build-push-action@v6
+          id: dh-push
+          with:
+            context: .
+            platforms: ${{ matrix.architecture }}
+            push: true
+            tags: ${{ steps.dh-meta.outputs.tags }}
+            labels: ${{ steps.dh-meta.outputs.labels }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+        - name: Generate and push artifact attestation to DockerHub
+          uses: actions/attest-build-provenance@v1
+          with:
+            subject-name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME}}
+            subject-digest: ${{ steps.dh-push.outputs.digest }}
+            push-to-registry: true

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -4,4 +4,4 @@
 [[ ! -z "${USER_GID}" ]] && groupmod -og ${USER_GID} node || echo "No USER_GID specified, leaving 1000"
 
 chown -R node:node /home/node
-exec su-exec node node ./src/www
+exec gosu node node ./src/www


### PR DESCRIPTION
There are quite a few bugs when using GitHub Actions along with `node:alpine` and `armv7`/`armv6` builds. This includes the following issues:
https://github.com/docker/build-push-action/issues/1071
https://github.com/docker/build-push-action/issues/977
https://github.com/nodejs/docker-node/issues/2077

I also tried some of the workarounds listed in the above issues, but instead got really strange errors:
```
docker run testingnotes
No USER_UID specified, leaving 1000
No USER_GID specified, leaving 1000
(node:1) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Generated session secret


#
# Fatal error in , line 0
# Check failed: module->status() == kLinked || module->status() == kEvaluated.
#
#
#
#FailureMessage Object: 0x7ffc01003cf0
----- Native stack trace -----
```

I split the container into the "build step" using Node v18, and then changed to use the "run step" at Node v20, copying over the node modules, etc., and the above error popped up every time.

So the next best option that I found was to instead use node's slim Debian container instead, so that we could at least get ARM builds out the door. We will have to drop ARMv6 compatibility, but instead we can then add ARM64v8 builds.

I know that Debian's slim containers are larger than Alpine's, but at least we can then have ARMv7 / ARM64v8.

I also had to change the `su-exec` command in the `start-docker.sh` to use `gosu` instead because we're using Debian.