### PR TITLE
Update start-docker.sh to be more distro-agnostic

### DIFF
--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -10,8 +10,8 @@ cat package.json | grep -v electron > server-package.json
 echo "Compiling typescript..."
 npx tsc
 
-sudo docker build -t triliumnext/notes:$VERSION --network host -t zadam/trilium:$SERIES .
+sudo docker build -t triliumnext/notes:$VERSION --network host -t triliumnext/notes:$SERIES .
 
 if [[ $VERSION != *"beta"* ]]; then
-  sudo docker tag zadam/trilium:$VERSION zadam/trilium:latest
+  sudo docker tag triliumnext/notes:$VERSION triliumnext/notes:latest
 fi

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -4,4 +4,4 @@
 [[ ! -z "${USER_GID}" ]] && groupmod -og ${USER_GID} node || echo "No USER_GID specified, leaving 1000"
 
 chown -R node:node /home/node
-exec gosu node node ./src/www
+exec su -c "node ./src/www" node


### PR DESCRIPTION
Update start-docker.sh to be more distro-agnostic.

Also update `build-docker.sh` to use `triliumnext/notes` instead of `zadam/trilium` for the tags it creates. 