### PR TITLE
Remove the strategy matrix for concurrent builds.

### DIFF
--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -16,7 +16,7 @@ env:
   DOCKERHUB_REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: triliumnext/notes:test
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm64/v8
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   test_docker:

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -20,136 +20,133 @@ env:
 
 jobs:
   test_docker:
-      name: Check Docker build
-      runs-on: ubuntu-latest
-      steps:
-          - name: Checkout the repository
-            uses: actions/checkout@v4
+    name: Check Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
 
-          - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-          - name: Set up node & dependencies
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20
-              cache: "npm"
-          
-          - run: npm ci
-          
-          - name: Run the TypeScript build
-            run: npx tsc
-          
-          - name: Create server-package.json
-            run: cat package.json | grep -v electron > server-package.json
+      - name: Set up node & dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      
+      - run: npm ci
+      
+      - name: Run the TypeScript build
+        run: npx tsc
+      
+      - name: Create server-package.json
+        run: cat package.json | grep -v electron > server-package.json
 
-          - name: Build and export to Docker
-            uses: docker/build-push-action@v6
-            with:
-              context: .
-              load: true
-              tags: ${{ env.TEST_TAG }}
-              cache-from: type=gha
-              cache-to: type=gha,mode=max
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.TEST_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-          - name: Run the container in the background
-            run: docker run -d --rm --name trilium_local ${{ env.TEST_TAG }}
+      - name: Run the container in the background
+        run: docker run -d --rm --name trilium_local ${{ env.TEST_TAG }}
 
-          - name: Wait for the healthchecks to pass
-            uses: stringbean/docker-healthcheck-action@v1
-            with:
-              container: trilium_local
-              wait-time: 50
-              require-status: running
-              require-healthy: true
+      - name: Wait for the healthchecks to pass
+        uses: stringbean/docker-healthcheck-action@v1
+        with:
+          container: trilium_local
+          wait-time: 50
+          require-status: running
+          require-healthy: true
 
   build_docker:
-      name: Build Docker images
-      runs-on: ubuntu-latest
-      needs:
-          - test_docker
-      permissions:
-        contents: read
-        packages: write
-        attestations: write
-        id-token: write
-      strategy:
-        matrix:
-          architecture: [linux/amd64, linux/arm64, linux/arm/v7, linux/arm64/v8]
-      steps:                        
-        - uses: actions/checkout@v4
-        - name: Extract metadata (tags, labels) for GHCR image
-          id: ghcr-meta
-          uses: docker/metadata-action@v4
-          with:
-            images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
-            tags: |
-              type=ref,event=branch
-              type=ref,event=tag
-              type=sha
-        - name: Extract metadata (tags, labels) for DockerHub image
-          id: dh-meta
-          uses: docker/metadata-action@v4
-          with:
-            images: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
-            tags: |
-              type=ref,event=branch
-              type=ref,event=tag
-              type=sha
-        - name: Set up node & dependencies
-          uses: actions/setup-node@v4
-          with:
-            node-version: 20
-            cache: "npm"
-        - run: npm ci
-        - name: Run the TypeScript build
-          run: npx tsc
-        - name: Create server-package.json
-          run: cat package.json | grep -v electron > server-package.json
-        - name: Log in to the GHCR container registry
-          uses: docker/login-action@v2
-          with:
-            registry: ${{ env.GHCR_REGISTRY }}
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
-        - uses: docker/setup-buildx-action@v3
-        - name: Build and push container image to GHCR
-          uses: docker/build-push-action@v6
-          id: ghcr-push
-          with:
-            context: .
-            platforms: ${{ matrix.architecture }}
-            push: true              
-            tags: ${{ steps.ghcr-meta.outputs.tags }}
-            labels: ${{ steps.ghcr-meta.outputs.labels }}
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
-        - name: Generate and push artifact attestation to GHCR
-          uses: actions/attest-build-provenance@v1
-          with:
-            subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME}}
-            subject-digest: ${{ steps.ghcr-push.outputs.digest }}
-            push-to-registry: true
-        - name: Log in to the DockerHub container registry
-          uses: docker/login-action@v2
-          with:
-            registry: ${{ env.DOCKERHUB_REGISTRY }}
-            username: ${{ secrets.DOCKERHUB_USERNAME }}
-            password: ${{ secrets.DOCKERHUB_TOKEN }}
-        - name: Build and push image to DockerHub
-          uses: docker/build-push-action@v6
-          id: dh-push
-          with:
-            context: .
-            platforms: ${{ matrix.architecture }}
-            push: true
-            tags: ${{ steps.dh-meta.outputs.tags }}
-            labels: ${{ steps.dh-meta.outputs.labels }}
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
-        - name: Generate and push artifact attestation to DockerHub
-          uses: actions/attest-build-provenance@v1
-          with:
-            subject-name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME}}
-            subject-digest: ${{ steps.dh-push.outputs.digest }}
-            push-to-registry: true
+    name: Build Docker images
+    runs-on: ubuntu-latest
+    needs:
+      - test_docker
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:                        
+      - uses: actions/checkout@v4
+      - name: Extract metadata (tags, labels) for GHCR image
+        id: ghcr-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+      - name: Extract metadata (tags, labels) for DockerHub image
+        id: dh-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+      - name: Set up node & dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - name: Run the TypeScript build
+        run: npx tsc
+      - name: Create server-package.json
+        run: cat package.json | grep -v electron > server-package.json
+      - name: Log in to the GHCR container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and push container image to GHCR
+        uses: docker/build-push-action@v6
+        id: ghcr-push
+        with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          push: true              
+          tags: ${{ steps.ghcr-meta.outputs.tags }}
+          labels: ${{ steps.ghcr-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Generate and push artifact attestation to GHCR
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.ghcr-push.outputs.digest }}
+          push-to-registry: true
+      - name: Log in to the DockerHub container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push image to DockerHub
+        uses: docker/build-push-action@v6
+        id: dh-push
+        with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.dh-meta.outputs.tags }}
+          labels: ${{ steps.dh-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Generate and push artifact attestation to DockerHub
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.dh-push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
The system to tag concurrent builds is simply just too finnicky right now, and isn't worth it. This change reverts it back to a sequential pipeline.

The other change in here is that `linux/arm64/v8` is normalized as `linux/arm64` currently within Docker. 