### PR TITLE
Fix a bug of find widget

### DIFF
--- a/src/public/app/widgets/find.js
+++ b/src/public/app/widgets/find.js
@@ -218,6 +218,10 @@ export default class FindWidget extends NoteContextAwareWidget {
      * @returns {Promise<void>}
      */
     async findNext(direction) {
+        if (this.$totalFound.text()=="?"){
+            await this.performFind();
+            return
+        }
         const searchTerm = this.$input.val();
         if (waitForEnter && this.searchTerm !== searchTerm) {
             await this.performFind();
@@ -271,5 +275,11 @@ export default class FindWidget extends NoteContextAwareWidget {
 
     isEnabled() {
         return super.isEnabled() && ['text', 'code', 'render'].includes(this.note.type);
+    }
+
+    async entitiesReloadedEvent({loadResults}) {
+        if (loadResults.isNoteContentReloaded(this.noteId)) {
+            this.$totalFound.text("?")  
+        } 
     }
 }


### PR DESCRIPTION
When finding, if you delete a find result in the note and then click to find the next one, an error will occur:
```
CKEditorError: mapping-model-position-view-parent-not-found {"modelPosition":{"root":"$graveyard","path":[0],"stickiness":"toNext"}}
Read more: https://ckeditor.com/docs/ckeditor5/latest/support/error-codes.html#error-mapping-model-position-view-parent-not-found
    at Nc.on.priority (<anonymous>:6:643867)
    at Nc.fire (<anonymous>:6:470940)
    at Nc.toViewPosition (<anonymous>:6:646343)
    at Nc.toViewRange (<anonymous>:6:646082)
    at n_.<anonymous> (<anonymous>:6:1032187)
    at m (<anonymous>:6:602325)
    at f (<anonymous>:6:602550)
    at p (<anonymous>:6:602439)
```
This pr makes it necessary to update the find results after modifying a note and then clicking on Find Previous and Next.