### PR TITLE
Update Spanish translation

### DIFF
--- a/src/public/translations/es/translation.json
+++ b/src/public/translations/es/translation.json
@@ -931,10 +931,10 @@
     "refresh": "Refrescar"
   },
   "consistency_checks": {
-    "title": "Comprobaciones de coherencia",
+    "title": "Comprobación de coherencia",
     "find_and_fix_button": "Buscar y solucionar problemas de coherencia",
-    "finding_and_fixing_message": "Encontrar y solucionar problemas de coherencia...",
-    "issues_fixed_message": "Los problemas de coherencia deben solucionarse."
+    "finding_and_fixing_message": "Buscando y solucionando problemas de coherencia...",
+    "issues_fixed_message": "Los problemas de coherencia han sido solucionados."
   },
   "database_anonymization": {
     "title": "Anonimización de bases de datos",

--- a/src/public/translations/es/translation.json
+++ b/src/public/translations/es/translation.json
@@ -1117,7 +1117,10 @@
   },
   "i18n": {
     "title": "Localización",
-    "language": "Idioma"
+    "language": "Idioma",
+    "first-day-of-the-week": "Primer día de la semana",
+    "sunday": "Dominigo",
+    "monday": "Lunes"
   },
   "backup": {
     "automatic_backup": "Copia de seguridad automática",


### PR DESCRIPTION
Addressing https://github.com/TriliumNext/Notes/pull/359#issuecomment-2323208797

Thanks for the notice.

Also noticed that my script replaced strings twice when the replacement should have be done only on the sub-string between `: "` and `"` :sweat_smile: 