### PR TITLE
The new instance makes the dialog box error not display

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,4 +14,7 @@
     "[javascript]": {
         "editor.defaultFormatter": "vscode.typescript-language-features"
     },
+    "[typescript]": {
+        "editor.defaultFormatter": "vscode.typescript-language-features"
+    },
 }

--- a/src/www.ts
+++ b/src/www.ts
@@ -149,8 +149,7 @@ function startHttpServer() {
                 // clicking the shortcut, the software icon, or the taskbar icon, or when creating a new window, 
                 // should simply focus on the existing window or open a new one, without displaying an error message.
                 if ("code" in error && error.code == 'EADDRINUSE') {
-                    const isNewWindow = process.argv.includes('--new-window');
-                    if (isNewWindow || !app.requestSingleInstanceLock()) {
+                    if (process.argv.includes('--new-window') || !app.requestSingleInstanceLock()) {
                         console.error(message);
                         process.exit(1);
                     }

--- a/src/www.ts
+++ b/src/www.ts
@@ -144,7 +144,17 @@ function startHttpServer() {
         }
 
         if (utils.isElectron()) {
-            import("electron").then(({ dialog }) => {
+            import("electron").then(({ app, dialog }) => {
+                // Not all situations require showing an error dialog. When Trilium is already open,
+                // clicking the shortcut, the software icon, or the taskbar icon, or when creating a new window, 
+                // should simply focus on the existing window or open a new one, without displaying an error message.
+                if ("code" in error && error.code == 'EADDRINUSE') {
+                    const isNewWindow = process.argv.includes('--new-window');
+                    if (isNewWindow || !app.requestSingleInstanceLock()) {
+                        console.error(message);
+                        process.exit(1);
+                    }
+                }
                 dialog.showErrorBox("Error while initializing the server", message);
                 process.exit(1);
             });


### PR DESCRIPTION
In the commit https://github.com/TriliumNext/Notes/commit/40651e985245bfaf4ae1e0e2bfc9d8b233bbc78a which improves error logging, an error message appears when clicking on the desktop shortcut, right-clicking on the taskbar icon, or selecting "New Window" from the taskbar if an Electron instance is already running. However, at this point, the port is already occupied. In the Electron version, it should simply focus on the main window without displaying an error message.
![图片](https://github.com/user-attachments/assets/834d5648-3581-4bed-ad66-dffeeb363756)

