### PR TITLE
i18n Fallback to English for null characters

### DIFF
--- a/src/public/app/services/i18n.js
+++ b/src/public/app/services/i18n.js
@@ -13,7 +13,8 @@ export async function initLocale() {
             fallbackLng: "en",
             backend: {
                 loadPath: `${window.glob.assetPath}/translations/{{lng}}/{{ns}}.json`
-            }
+            },
+            returnEmptyString: false
         });
 }
 


### PR DESCRIPTION
Let i18n fall back to English for untranslated text to avoid displaying it as blank:
![} {%_A{@D@1OD@4E{{Y3@JI](https://github.com/user-attachments/assets/ae719dff-25ed-4bc3-a54b-76cfed3d69d8)

