### PR TITLE
Add explicit permissions for GITHUB_TOKEN for package access

### DIFF
--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -17,8 +17,11 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/notes
   TEST_TAG: ${{ github.repository_owner }}/notes:test
 
-jobs:
+permissions:
+  contents: read
+  packages: write
 
+jobs:
   test_docker:
     name: Check Docker build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Suggested as a fix [here](https://github.com/docker/build-push-action/issues/687#issuecomment-1651816012) for our issue [here](https://github.com/TriliumNext/Notes/actions/runs/10835704275/job/30068384041#step:9:276). Otherwise, we may have to take a look at what is enabled in the repository [here](https://github.com/docker/build-push-action/issues/687#issuecomment-1238980158), or give [this](https://github.com/orgs/community/discussions/26274#discussioncomment-3251137) a shot.
