### PR TITLE
Fix global menu advanced command can't click

### DIFF
--- a/src/public/app/widgets/buttons/global_menu.js
+++ b/src/public/app/widgets/buttons/global_menu.js
@@ -280,7 +280,9 @@ export default class GlobalMenuWidget extends BasicWidget {
             this.dropdown.toggle();
         });
         this.$widget.on('click', '.dropdown-submenu', e => {
-            e.stopPropagation();
+            if ($(e.target).children(".dropdown-menu").length === 1 || $(e.target).hasClass('dropdown-toggle')) {
+                e.stopPropagation();
+            }
         })
 
         this.$widget.find(".global-menu-button-update-available").append(


### PR DESCRIPTION
`e.stopPropagation();` is preventing when click on `Advanced` to close the global menu, but it also prevent it's submenu buttons. Adding conditions to only take effect when click on `Advanced` button.