### PR TITLE
Use the electron Clipboard module when using "Copy image to clipboard"

### DIFF
--- a/src/public/app/menus/image_context_menu.js
+++ b/src/public/app/menus/image_context_menu.js
@@ -22,22 +22,28 @@ function setupContextMenu($image) {
                     command: "copyImageReferenceToClipboard",
                     uiIcon: "bx bx-empty"
                 },
-                {title: "Copy image to clipboard", command: "copyImageToClipboard", uiIcon: "bx bx-empty"},
+                { title: "Copy image to clipboard", command: "copyImageToClipboard", uiIcon: "bx bx-empty" },
             ],
-            selectMenuItemHandler: async ({command}) => {
+            selectMenuItemHandler: async ({ command }) => {
                 if (command === 'copyImageReferenceToClipboard') {
                     imageService.copyImageReferenceToClipboard($image);
                 } else if (command === 'copyImageToClipboard') {
                     try {
-                        const imageUrl = $image.attr('src');
-                        const response = await fetch(imageUrl);
-                        const blob = await response.blob();
-                        const arrayBuffer = await blob.arrayBuffer();
-                        const buffer = Buffer.from(arrayBuffer);
                         const nativeImage = utils.dynamicRequire('electron').nativeImage;
                         const clipboard = utils.dynamicRequire('electron').clipboard;
-                        const image = nativeImage.createFromBuffer(buffer);
-                        clipboard.writeImage(image);
+
+                        const response = await fetch(
+                            $image.attr('src')
+                        );
+                        const blob = await response.blob();
+
+                        clipboard.writeImage(
+                            nativeImage.createFromBuffer(
+                                Buffer.from(
+                                    await blob.arrayBuffer()
+                                )
+                            )
+                        );
                     } catch (error) {
                         console.error('Failed to copy image to clipboard:', error);
                     }


### PR DESCRIPTION
Currently, when right clicking on an image and using "Copy image to clipboard" and then pasting the image in another application (like Trilium running in the web browser) has it paste a broken image. This is the context menu in question:
![image](https://github.com/user-attachments/assets/da5292fe-1a28-4c12-ba70-c4d8dc8cf241)

And this is what it shows when pasting the above image into Trilium running in the browser:
![image](https://github.com/user-attachments/assets/fbf13409-f654-4f64-9bf1-b94f7c9b7820)

These changes change the context menu from using `copyImageAt` to electron's `clipboard`, and fix the above scenario.