### PR TITLE
Override the z-index of Bootstrap tooltips

### DIFF
--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -460,6 +460,7 @@ table.promoted-attributes-in-tooltip td, table.promoted-attributes-in-tooltip th
 
 .tooltip {
     font-size: var(--main-font-size) !important;
+    z-index: calc(var(--ck-z-panel) - 1) !important;
 }
 
 .tooltip-trigger {
@@ -958,14 +959,6 @@ li.dropdown-submenu:hover > ul.dropdown-menu {
 .ck.ck-mentions > .ck-list__item .ck-button {
     /* wrap text for very long note path title */
     white-space: normal !important;
-}
-
-/**
-    ckeditor's autocomplete
-    should be higher than 1070 of tooltip
-*/
-.ck.ck-balloon-panel {
-    z-index: 1101;
 }
 
 .area-expander {


### PR DESCRIPTION
This change overrides the z-index of Bootstrap tooltips (calculates to 1080 in the current version) to the value assigned to CKEditor Panel Balloons (calculates to 1000 in the current version) minus 1. It also removes the original override to the CKEditor Panel Balloons which forces the autocomplete box to appear above tooltips, which is no longer needed and would interfere with math preview boxes.

This change fixes the regression to the [original issue][1] and the [math preview issue][2]. One notable effect is that tooltips will not cover menus when overlapped with one, including menus opened from the top-right corner. Not sure if it is considered normal or not.

Fixes #297.

[1]: https://github.com/zadam/trilium/issues/1272
[2]: https://github.com/TriliumNext/Notes/issues/297