### PR TITLE
Move Description section to top of bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,12 @@ description: Report a bug
 title: "(Bug report) "
 labels: "Type: Bug"
 body:
+- type: textarea
+  attributes:
+    label: Description
+    description: A clear and concise description of the bug and any additional information.
+  validations:
+    required: true
 - type: input
   attributes:
     label: TriliumNext Version
@@ -36,12 +42,6 @@ body:
     label: Operating System Version
     description: What operating system version are you using? On Windows, click Start button > Settings > System > About. On macOS, click the Apple Menu > About This Mac. On Linux, use lsb_release or uname -a.
     placeholder: "e.g. Windows 10 version 1909, macOS Catalina 10.15.7, or Ubuntu 20.04"
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Description
-    description: A clear and concise description of the bug and any additional information.
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
This would make it easier to quickly find the issue description since it would be located at the top of the issue report. 

This is a current issue report as seen in a Github email notification (Sometimes the description isn't even visible without scrolling down).

![image](https://github.com/user-attachments/assets/302347b0-cdc1-449e-ab22-eb738f4ac350)
