### PR TITLE
Continue Spanish translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 src/public/app-dist/
 npm-debug.log
 yarn-error.log
+po-*/
 
 *.db
 !integration-tests/db/document.db

--- a/bin/translation.sh
+++ b/bin/translation.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# --------------------------------------------------------------------------------------------------
+#
+# Create PO files to make easier the labor of translation.
+#
+# Info:
+# 	https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+# 	https://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/json2po.html
+#
+# Dependencies:
+# 	jq
+# 	translate-toolkit
+# 		python-wcwidth
+#
+# Created by @hasecilu
+#
+# --------------------------------------------------------------------------------------------------
+
+stats() {
+	# Print the number of existing strings on the JSON files for each locale
+	s=$(jq 'path(..) | select(length == 2) | .[1]' "${paths[0]}/en/server.json" | wc -l)
+	c=$(jq 'path(..) | select(length == 2) | .[1]' "${paths[1]}/en/translation.json" | wc -l)
+	echo "|locale |server strings |client strings |"
+	echo "|-------|---------------|---------------|"
+	echo "|  en   |      ${s}      |     ${c}      |"
+	for locale in "${locales[@]}"; do
+		s=$(jq 'path(..) | select(length == 2) | .[1]' "${paths[0]}/${locale}/server.json" | wc -l)
+		c=$(jq 'path(..) | select(length == 2) | .[1]' "${paths[1]}/${locale}/translation.json" | wc -l)
+		echo "|  ${locale}   |      ${s}      |     ${c}      |"
+	done
+}
+
+help() {
+	echo -e "\nDescription:"
+	echo -e "\tCreate PO files to make easier the labor of translation"
+	echo -e "\nUsage:"
+	echo -e "\t./translation.sh [--stats] [--update <OPT_LOCALE>] [--update2 <OPT_LOCALE>]"
+	echo -e "\nFlags:"
+	echo -e "  --clear\n\tClear all po-* directories"
+	echo -e "  --stats\n\tPrint the number of existing strings on the JSON files for each locale"
+	echo -e "  --update <LOCALE>\n\tUpdate PO files from English and localized JSON files as source"
+	echo -e "  --update2 <LOCALE>\n\tRecover translation from PO files to localized JSON files"
+}
+
+# Main function ------------------------------------------------------------------------------------
+
+# Get script directory to set file path relative to it
+file_path="$(
+	cd -- "$(dirname "${0}")" >/dev/null 2>&1 || exit
+	pwd -P
+)"
+paths=("${file_path}/../translations/" "${file_path}/../src/public/translations/")
+locales=(cn es fr ro)
+
+if [ $# -eq 1 ]; then
+	if [ "$1" == "--clear" ]; then
+		for path in "${paths[@]}"; do
+			for locale in "${locales[@]}"; do
+				[ -d "${path}/po-${locale}" ] && rm -r "${path}/po-${locale}"
+			done
+		done
+	elif [ "$1" == "--stats" ]; then
+		stats
+	elif [ "$1" == "--update" ]; then
+		# Update PO files from English and localized JSON files as source
+		for path in "${paths[@]}"; do
+			for locale in "${locales[@]}"; do
+				json2po -t "${path}/en" "${path}/${locale}" "${path}/po-${locale}"
+			done
+		done
+	elif [ "$1" == "--update2" ]; then
+		# Recover translation from PO files to localized JSON files
+		for path in "${paths[@]}"; do
+			for locale in "${locales[@]}"; do
+				po2json -t "${path}/en" "${path}/po-${locale}" "${path}/${locale}"
+			done
+		done
+	else
+		help
+	fi
+elif [ $# -eq 2 ]; then
+	if [ "$1" == "--update" ]; then
+		locale="$2"
+		for path in "${paths[@]}"; do
+			json2po -t "${path}/en" "${path}/${locale}" "${path}/po-${locale}"
+		done
+	elif [ "$1" == "--update2" ]; then
+		locale="$2"
+		for path in "${paths[@]}"; do
+			po2json -t "${path}/en" "${path}/po-${locale}" "${path}/${locale}"
+		done
+	else
+		help
+	fi
+else
+	help
+fi

--- a/src/public/translations/es/translation.json
+++ b/src/public/translations/es/translation.json
@@ -247,6 +247,9 @@
     "revisions_deleted": "Se han eliminado las revisiones de nota.",
     "revision_restored": "Se ha restaurado la revisión de nota.",
     "revision_deleted": "Se ha eliminado la revisión de la nota.",
+    "snapshot_interval": "Intervalo de respaldo de revisiones de nota: {{seconds}}s.",
+    "maximum_revisions": "Máximo de revisiones para la nota actual: {{number}}.",
+    "settings": "Ajustes para revisiones de nota",
     "download_button": "Descargar",
     "mime": "MIME: ",
     "file_size": "Tamaño del archivo:",
@@ -344,13 +347,13 @@
     "widget": "marca esta nota como un widget personalizado que se agregará al árbol de componentes de Trilium",
     "workspace": "marca esta nota como un espacio de trabajo que permite un fácil levantamiento",
     "workspace_icon_class": "define la clase CSS del ícono de cuadro que se usará en la pestaña cuando se levante a esta nota",
-    "workspace_tab_background_color": "color CSS utilizado en la pestaña de nota cuando se eleva a esta nota",
+    "workspace_tab_background_color": "color CSS utilizado en la pestaña de nota cuando se ancla a esta nota",
     "workspace_calendar_root": "Define la raíz del calendario por cada espacio de trabajo",
     "workspace_template": "Esta nota aparecerá en la selección de plantillas disponibles al crear una nueva nota, pero solo cuando se levante a un espacio de trabajo que contenga esta plantilla",
     "search_home": "se crearán nuevas notas de búsqueda como hijas de esta nota",
-    "workspace_search_home": "se crearán nuevas notas de búsqueda como hijo de esta nota cuando se elevan a algún antecesor de esta nota del espacio de trabajo",
+    "workspace_search_home": "se crearán nuevas notas de búsqueda como hijo de esta nota cuando se anclan a algún antecesor de esta nota del espacio de trabajo",
     "inbox": "ubicación predeterminada de la bandeja de entrada para nuevas notas - cuando crea una nota usando el botón \"nueva nota\" en la barra lateral, las notas serán creadas como notas hijo de la nota marcada con la etiqueta <code>#inbox</code>.",
-    "workspace_inbox": "ubicación predeterminada de la bandeja de entrada para nuevas notas cuando se elevan a algún antecesor de esta nota del espacio de trabajo",
+    "workspace_inbox": "ubicación predeterminada de la bandeja de entrada para nuevas notas cuando se anclan a algún antecesor de esta nota del espacio de trabajo",
     "sql_console_home": "ubicación predeterminada de las notas de la consola SQL",
     "bookmark_folder": "la nota con esta etiqueta aparecerá en los marcadores como carpeta (permitiendo el acceso a sus elementos hijos).",
     "share_hidden_from_tree": "esta nota está oculta en el árbol de navegación izquierdo, pero aún se puede acceder a ella con su URL",
@@ -370,7 +373,7 @@
     "toc": "<code>#toc</code> o <code>#toc=show</code> forzará que se muestre la tabla de contenido, <code>#toc=hide</code> forzará a ocultarla. Si la etiqueta no existe, se observa la configuración global",
     "color": "define el color de la nota en el árbol de notas, enlaces, etc. Utilice cualquier valor de color CSS válido como 'red' o #a13d5f",
     "keyboard_shortcut": "Define un atajo de teclado que saltará inmediatamente a esta nota. Ejemplo: 'ctrl+alt+e'. Es necesario recargar la interfaz para que el cambio surta efecto.",
-    "keep_current_hoisting": "Abrir este enlace no cambiará la elevación incluso si la nota no se puede mostrar en el subárbol elevado actual.",
+    "keep_current_hoisting": "Abrir este enlace no cambiará el anclaje incluso si la nota no se puede mostrar en el subárbol anclado actualmente.",
     "execute_button": "Título del botón que ejecutará la nota de código actual",
     "execute_description": "Descripción más larga de la nota de código actual que se muestra junto con el botón de ejecución",
     "exclude_from_note_map": "Las notas con esta etiqueta se ocultarán del Mapa de notas",
@@ -759,7 +762,7 @@
     "clone_button": "Clonar nota a nueva ubicación...",
     "intro_placed": "Esta nota está colocada en las siguientes rutas:",
     "intro_not_placed": "Esta nota aún no se ha colocado en el árbol de notas.",
-    "outside_hoisted": "Esta ruta está fuera de la nota elevada y habría que bajarla.",
+    "outside_hoisted": "Esta ruta está fuera de la nota anclada y habría que bajarla.",
     "archived": "Archivado",
     "search": "Buscar"
   },
@@ -1090,6 +1093,13 @@
     "note_revisions_snapshot_description": "El intervalo de tiempo de la instantánea de revisión de nota es el tiempo en segundos después de lo cual se creará una nueva revisión para la nota. Ver <a href=\"https://triliumnext.github.io/docs/wiki/note-revisions.html\" class=\"external\"> wiki </a> para obtener más información.",
     "snapshot_time_interval_label": "Intervalo de tiempo de la instantánea de revisión de notas (en segundos)"
   },
+  "revisions_snapshot_limit": {
+    "note_revisions_snapshot_limit_title": "Límite de respaldos de revisiones de nota",
+    "note_revisions_snapshot_limit_description": "El límite de número de respaldos de revisiones de notas se refiere al número máximo de revisiones que pueden guardarse para cada nota. Donde -1 significa sin límite, 0 significa borrar todas las revisiones. Puede establecer el máximo de revisiones para una sola nota a través de la etiqueta #versioningLimit.",
+    "snapshot_number_limit_label": "Número límite de respaldos de revisiones de nota:",
+    "erase_excess_revision_snapshots": "Eliminar el exceso de respaldos de revisiones ahora",
+    "erase_excess_revision_snapshots_prompt": "El exceso de respaldos de revisiones han sido eliminadas."
+  },
   "search_engine": {
     "title": "Motor de búsqueda",
     "custom_search_engine_info": "El motor de búsqueda personalizado requiere que se establezcan un nombre y una URL. Si alguno de estos no está configurado, DuckDuckGo se utilizará como motor de búsqueda predeterminado.",
@@ -1280,6 +1290,8 @@
     "insert-child-note": "Insertar nota hijo",
     "delete": "Eliminar",
     "search-in-subtree": "Buscar en subárbol",
+    "hoist-note": "Anclar nota",
+    "unhoist-note": "Desanclar nota",
     "edit-branch-prefix": "Editar prefijo de rama",
     "advanced": "Avanzado",
     "expand-subtree": "Expandir subárbol",
@@ -1391,5 +1403,26 @@
   },
   "sql_table_schemas": {
     "tables": "Tablas"
+  },
+  "tab_row": {
+    "close_tab": "Cerrar pestaña",
+    "add_new_tab": "Agregar nueva pestaña",
+    "close": "Cerrar",
+    "close_other_tabs": "Cerrar otras pestañas",
+    "close_all_tabs": "Cerras todas las pestañas",
+    "move_tab_to_new_window": "Mover esta pestaña a una nueva ventana",
+    "new_tab": "Nueva pestaña"
+  },
+  "toc": {
+    "table_of_contents": "Tabla de contenido",
+    "options": "Opciones"
+  },
+  "watched_file_update_status": {
+    "file_last_modified": "Archivo <code class=\"file-path\"></code> ha sido modificado por última vez en<span class=\"file-last-modified\"></span>.",
+    "upload_modified_file": "Subir archivo modificado",
+    "ignore_this_change": "Ignorar este cambio"
+  },
+  "app_context": {
+    "please_wait_for_save": "Por favor espere algunos segundos a que se termine de guardar, después intente de nuevo."
   }
 }


### PR DESCRIPTION
### Script
The same idea I mentioned on #449
```shell
$  ./bin/translation.sh

Description:
        Create PO files to make easier the labor of translation

Usage:
        ./translation.sh [--stats] [--update <OPT_LOCALE>] [--update2 <OPT_LOCALE>]

Flags:
  --clear
        Clear all po-* directories
  --stats
        Print the number of existing strings on the JSON files for each locale
  --update <LOCALE>
        Update PO files from English and localized JSON files as source
  --update2 <LOCALE>
        Recover translation from PO files to localized JSON files
```

![image](https://github.com/user-attachments/assets/50227268-7dc2-4c69-b4c2-b8e3c9621553)
