### PR TITLE
Automatically show recent notes

### DIFF
--- a/src/public/app/widgets/type_widgets/empty.js
+++ b/src/public/app/widgets/type_widgets/empty.js
@@ -83,7 +83,15 @@ export default class EmptyTypeWidget extends TypeWidget {
                     .on('click', () => this.triggerCommand('hoistNote', {noteId: workspaceNote.noteId}))
             );
         }
-        noteAutocompleteService.showRecentNotes(this.$autoComplete);
+        // Automatically trigger autocomplete on focus, which can achieve:
+        // 1. Automatically display suggestions when $el is focused, without needing to input any text.
+        // 2. Automatically show recent notes when creating a new tab.
+        this.$autoComplete.on('focus', () => {
+            // simulate pressing down arrow to trigger autocomplete
+            const e = $.Event('keydown');
+            e.which = 40; // arrow down
+            this.$autoComplete.trigger(e);
+        });
         this.$autoComplete
             .trigger('focus')
             .trigger('select');

--- a/src/public/app/widgets/type_widgets/empty.js
+++ b/src/public/app/widgets/type_widgets/empty.js
@@ -89,9 +89,8 @@ export default class EmptyTypeWidget extends TypeWidget {
         // 2. Automatically show recent notes when creating a new tab.
         this.$autoComplete.on('focus', () => {
             // simulate pressing down arrow to trigger autocomplete
-            const e = $.Event('keydown');
-            e.which = 40; // arrow down
-            this.$autoComplete.trigger(e);
+            this.$autoComplete.trigger($.Event('keydown', { which: 40 })); // arrow down
+            this.$autoComplete.trigger($.Event('keydown', { which: 38 })); // arrow up
         });
         
         this.$autoComplete

--- a/src/public/app/widgets/type_widgets/empty.js
+++ b/src/public/app/widgets/type_widgets/empty.js
@@ -83,7 +83,7 @@ export default class EmptyTypeWidget extends TypeWidget {
                     .on('click', () => this.triggerCommand('hoistNote', {noteId: workspaceNote.noteId}))
             );
         }
-
+        noteAutocompleteService.showRecentNotes(this.$autoComplete);
         this.$autoComplete
             .trigger('focus')
             .trigger('select');

--- a/src/public/app/widgets/type_widgets/empty.js
+++ b/src/public/app/widgets/type_widgets/empty.js
@@ -83,6 +83,7 @@ export default class EmptyTypeWidget extends TypeWidget {
                     .on('click', () => this.triggerCommand('hoistNote', {noteId: workspaceNote.noteId}))
             );
         }
+
         // Automatically trigger autocomplete on focus, which can achieve:
         // 1. Automatically display suggestions when $el is focused, without needing to input any text.
         // 2. Automatically show recent notes when creating a new tab.
@@ -92,6 +93,7 @@ export default class EmptyTypeWidget extends TypeWidget {
             e.which = 40; // arrow down
             this.$autoComplete.trigger(e);
         });
+        
         this.$autoComplete
             .trigger('focus')
             .trigger('select');

--- a/src/public/app/widgets/type_widgets/empty.js
+++ b/src/public/app/widgets/type_widgets/empty.js
@@ -85,7 +85,7 @@ export default class EmptyTypeWidget extends TypeWidget {
         }
 
         // Automatically trigger autocomplete on focus, which can achieve:
-        // 1. Automatically display suggestions when $el is focused, without needing to input any text.
+        // 1. Automatically display suggestions when input is focused, without needing to input any text.
         // 2. Automatically show recent notes when creating a new tab.
         this.$autoComplete.on('focus', () => {
             // simulate pressing down arrow to trigger autocomplete


### PR DESCRIPTION
1. Automatically display suggestions when input is focused, without needing to input any text.
2. Automatically show recent notes when creating a new tab.