### PR TITLE
Automatically trigger autocomplete on focus.

### DIFF
--- a/src/public/app/widgets/type_widgets/empty.js
+++ b/src/public/app/widgets/type_widgets/empty.js
@@ -84,6 +84,13 @@ export default class EmptyTypeWidget extends TypeWidget {
             );
         }
 
+        // Automatically trigger autocomplete on focus.
+        this.$autoComplete.on('focus', () => {
+            // simulate pressing down arrow to trigger autocomplete
+            this.$autoComplete.trigger($.Event('keydown', { which: 40 })); // arrow down
+            this.$autoComplete.trigger($.Event('keydown', { which: 38 })); // arrow up
+        });
+        
         this.$autoComplete
             .trigger('focus')
             .trigger('select');


### PR DESCRIPTION
Automatically trigger autocomplete on focus, which can achieve:
 1. Automatically display suggestions when input is focused, without needing to input any text.
 2. Automatically show recent notes when creating a new tab.