### PR TITLE
Make attachments open in a new tab/browser

### DIFF
--- a/src/public/app/widgets/type_widgets/abstract_text_type_widget.js
+++ b/src/public/app/widgets/type_widgets/abstract_text_type_widget.js
@@ -32,7 +32,7 @@ export default class AbstractTextTypeWidget extends TypeWidget {
 
     async openImageInCurrentTab($img) {
         const { noteId, viewScope } = await this.parseFromImage($img);
-
+        
         if (noteId) {
             appContext.tabManager.getActiveContext().setNote(noteId, { viewScope });
         } else {
@@ -40,8 +40,8 @@ export default class AbstractTextTypeWidget extends TypeWidget {
         }
     }
 
-    openImageInNewTab($img) {
-        const { noteId, viewScope } = this.parseFromImage($img);
+    async openImageInNewTab($img) {
+        const { noteId, viewScope } = await this.parseFromImage($img);
 
         if (noteId) {
             appContext.tabManager.openTabWithNoteWithHoisting(noteId, { viewScope });

--- a/src/services/window.ts
+++ b/src/services/window.ts
@@ -111,13 +111,9 @@ async function createMainWindow(app: App) {
 }
 
 function configureWebContents(webContents: WebContents, spellcheckEnabled: boolean) {
-    if (!mainWindow) {
-        return;
-    }
-
     remoteMain.enable(webContents);
 
-    mainWindow.webContents.setWindowOpenHandler((details) => {
+    webContents.setWindowOpenHandler((details) => {
         async function openExternal() {
             (await import('electron')).shell.openExternal(details.url);
         }


### PR DESCRIPTION
Related to https://github.com/TriliumNext/trilium/issues/5249.
1. The changes in `abstract_text_type_widget.js` allow images to open in a new tab when holding down the Ctrl key.

2. It’s unclear why `configureWebContents` was originally executed only in the main window within `src/services/window.ts`, which prevented `configureWebContents` from working properly in the extra window. Therefore, I removed:
```javascript
if (!mainWindow) {
    return;
}
```
because it prevented `extraWindow` from opening links in the browser.