### PR TITLE
 Add more link protocol support

### DIFF
--- a/src/public/app/services/link.js
+++ b/src/public/app/services/link.js
@@ -259,7 +259,7 @@ function goToLinkExt(evt, hrefLink, $link) {
                 // Enable protocols supported by CKEditor 5 to be clickable. 
                 // Refer to `allowedProtocols` in https://github.com/TriliumNext/trilium-ckeditor5/blob/main/packages/ckeditor5-build-balloon-block/src/ckeditor.ts.
                 // Adding `:` to these links might be safer.
-                const otherAllowedProtocols = ['tel:', 'sms:', 'sftp:', 'smb:', 'slack:', 'file:', 'zotero:'];
+                const otherAllowedProtocols = ['mailto:', 'tel:', 'sms:', 'sftp:', 'smb:', 'slack:', 'file:', 'zotero:'];
                 if (otherAllowedProtocols.some(protocol => hrefLink.startsWith(protocol))){
                     window.open(hrefLink, '_blank');
                 }

--- a/src/public/app/services/link.js
+++ b/src/public/app/services/link.js
@@ -254,8 +254,15 @@ function goToLinkExt(evt, hrefLink, $link) {
                 window.open(hrefLink, '_blank');
             } else if (hrefLink.toLowerCase().startsWith('file:') && utils.isElectron()) {
                 const electron = utils.dynamicRequire('electron');
-
                 electron.shell.openPath(hrefLink);
+            } else {
+                // Enable protocols supported by CKEditor 5 to be clickable. 
+                // Refer to `allowedProtocols` in https://github.com/TriliumNext/trilium-ckeditor5/blob/main/packages/ckeditor5-build-balloon-block/src/ckeditor.ts.
+                // Adding `:` to these links might be safer.
+                const otherAllowedProtocols = ['tel:', 'sms:', 'sftp:', 'smb:', 'slack:', 'file:', 'zotero:'];
+                if (otherAllowedProtocols.some(protocol => hrefLink.startsWith(protocol))){
+                    window.open(hrefLink, '_blank');
+                }
             }
         }
     }


### PR DESCRIPTION
Related to https://github.com/TriliumNext/trilium-ckeditor5/pull/2.
Although CKEditor 5 supports them, Trilium ignores these links. This PR adds them.