### PR TITLE
Add "Reopen last tab" and "Copy tab to new window" to tab management

### DIFF
--- a/src/public/app/components/tab_manager.js
+++ b/src/public/app/components/tab_manager.js
@@ -586,6 +586,11 @@ export default class TabManager extends Component {
         }
     }
 
+    async copyTabToNewWindowCommand({ntxId}) {
+        const {notePath, hoistedNoteId} = this.getNoteContextById(ntxId);
+        this.triggerCommand('openInWindow', {notePath, hoistedNoteId});
+    } 
+
     async reopenLastTabCommand() {
         let closeLastEmptyTab = null;
 

--- a/src/public/app/widgets/tab_row.js
+++ b/src/public/app/widgets/tab_row.js
@@ -259,14 +259,19 @@ export default class TabRowWidget extends BasicWidget {
                 x: e.pageX,
                 y: e.pageY,
                 items: [
-                    {title: t('tab_row.close'), command: "closeTab", uiIcon: "bx bxs-x-circle"},
+                    {title: t('tab_row.close'), command: "closeTab", uiIcon: "bx bx-x"},
                     {title: t('tab_row.close_other_tabs'), command: "closeOtherTabs", uiIcon: "bx bx-empty", enabled: appContext.tabManager.noteContexts.length !== 1},
                     {title: t('tab_row.close_right_tabs'), command: "closeRightTabs", uiIcon: "bx bx-empty", enabled: appContext.tabManager.noteContexts.at(-1).ntxId !== ntxId},
                     {title: t('tab_row.close_all_tabs'), command: "closeAllTabs", uiIcon: "bx bx-empty"},
 
                     {title: "----"},
+
+                    {title: t('tab_row.reopen_last_tab'), command: "reopenLastTab", uiIcon: "bx bx-undo", enabled: appContext.tabManager.recentlyClosedTabs.length !== 0},
+
+                    {title: "----"},
                     
                     {title: t('tab_row.move_tab_to_new_window'), command: "moveTabToNewWindow", uiIcon: "bx bx-window-open"},
+                    {title: t('tab_row.copy_tab_to_new_window'), command: "copyTabToNewWindow", uiIcon: "bx bx-empty"}
                 ],
                 selectMenuItemHandler: ({command}) => {
                     this.triggerCommand(command, {ntxId});

--- a/src/public/translations/en/translation.json
+++ b/src/public/translations/en/translation.json
@@ -1445,7 +1445,9 @@
     "close_other_tabs": "Close other tabs",
     "close_right_tabs": "Close tabs to the right",
     "close_all_tabs": "Close all tabs",
+    "reopen_last_tab": "Reopen closed tab",
     "move_tab_to_new_window": "Move this tab to a new window",
+    "copy_tab_to_new_window": "Copy this tab to a new window",
     "new_tab": "New tab"
   },
   "toc": {


### PR DESCRIPTION
1. Add `reopen_last_tab`: `CTRL+Shift+T` might not be widely known
2. Add `copy_tab_to_new_window`: Sometimes, users might not want to close the original tab in the current window
3. `bxs-x-circle` => `bx-x`: To be consistent with the ico of `.note-tab-close`
![图片](https://github.com/user-attachments/assets/1ef569e9-2277-4ab5-b6e0-23481fc6b161)
