### PR TITLE
Add label definition type for standalone time

### DIFF
--- a/src/public/app/services/promoted_attribute_definition_parser.js
+++ b/src/public/app/services/promoted_attribute_definition_parser.js
@@ -6,7 +6,7 @@ function parse(value) {
         if (token === 'promoted') {
             defObj.isPromoted = true;
         }
-        else if (['text', 'number', 'boolean', 'date', 'datetime', 'url'].includes(token)) {
+        else if (['text', 'number', 'boolean', 'date', 'datetime', 'time', 'url'].includes(token)) {
             defObj.labelType = token;
         }
         else if (['single', 'multi'].includes(token)) {

--- a/src/public/app/widgets/attribute_widgets/attribute_detail.js
+++ b/src/public/app/widgets/attribute_widgets/attribute_detail.js
@@ -125,6 +125,7 @@ const TPL = `
                   <option value="boolean">${t('attribute_detail.boolean')}</option>
                   <option value="date">${t('attribute_detail.date')}</option>
                   <option value="datetime">${t('attribute_detail.date_time')}</option>
+                  <option value="time">${t('attribute_detail.time')}</option>
                   <option value="url">${t('attribute_detail.url')}</option>
                 </select>
             </td>

--- a/src/public/app/widgets/ribbon_widgets/promoted_attributes.js
+++ b/src/public/app/widgets/ribbon_widgets/promoted_attributes.js
@@ -225,6 +225,9 @@ export default class PromotedAttributesWidget extends NoteContextAwareWidget {
             else if (definition.labelType === 'datetime') {
                 $input.prop('type', 'datetime-local')
             }
+            else if (definition.labelType === 'time') {
+                $input.prop('type', 'time')
+            }
             else if (definition.labelType === 'url') {
                 $input.prop("placeholder", t("promoted_attributes.url_placeholder"));
 

--- a/src/public/translations/cn/translation.json
+++ b/src/public/translations/cn/translation.json
@@ -304,6 +304,7 @@
     "boolean": "布尔值",
     "date": "日期",
     "date_time": "日期和时间",
+    "time": "时间",
     "url": "网址",
     "precision_title": "值设置界面中浮点数后的位数。",
     "precision": "精度",

--- a/src/public/translations/de/translation.json
+++ b/src/public/translations/de/translation.json
@@ -310,6 +310,7 @@
     "boolean": "Boolescher Wert",
     "date": "Datum",
     "date_time": "Datum und Uhrzeit",
+    "time": "Uhrzeit",
     "url": "URL",
     "precision_title": "Wie viele Nachkommastellen im Wert-Einstellungs-Interface verfügbar sein sollen.",
     "precision": "Präzision",

--- a/src/public/translations/en/translation.json
+++ b/src/public/translations/en/translation.json
@@ -315,6 +315,7 @@
     "boolean": "Boolean",
     "date": "Date",
     "date_time": "Date & Time",
+    "time": "Time",
     "url": "URL",
     "precision_title": "What number of digits after floating point should be available in the value setting interface.",
     "precision": "Precision",

--- a/src/public/translations/es/translation.json
+++ b/src/public/translations/es/translation.json
@@ -311,6 +311,7 @@
     "boolean": "Booleano",
     "date": "Fecha",
     "date_time": "Fecha y hora",
+    "time": "Hora",
     "url": "URL",
     "precision_title": "Cantidad de dígitos después del punto flotante que deben estar disponibles en la interfaz de configuración del valor.",
     "precision": "Precisión",

--- a/src/public/translations/fr/translation.json
+++ b/src/public/translations/fr/translation.json
@@ -311,6 +311,7 @@
     "boolean": "Booléen",
     "date": "Date",
     "date_time": "Date et heure",
+    "time": "Heure",
     "url": "URL",
     "precision_title": "Nombre de chiffres après la virgule devant être disponible dans l'interface définissant la valeur.",
     "precision": "Précision",

--- a/src/public/translations/ro/translation.json
+++ b/src/public/translations/ro/translation.json
@@ -127,6 +127,7 @@
     "custom_resource_provider": "a se vedea <a href=\"javascript:\" data-help-page=\"custom-request-handler.html\">Custom request handler</a>",
     "date": "Dată",
     "date_time": "Dată și timp",
+    "time": "Timp",
     "delete": "Șterge",
     "digits": "număr de zecimale",
     "disable_inclusion": "script-urile cu această etichetă nu vor fi incluse în execuția scriptului părinte.",

--- a/src/services/promoted_attribute_definition_parser.ts
+++ b/src/services/promoted_attribute_definition_parser.ts
@@ -8,7 +8,7 @@ function parse(value: string): DefinitionObject {
         if (token === 'promoted') {
             defObj.isPromoted = true;
         }
-        else if (['text', 'number', 'boolean', 'date', 'datetime', 'url'].includes(token)) {
+        else if (['text', 'number', 'boolean', 'date', 'datetime', 'time', 'url'].includes(token)) {
             defObj.labelType = token;
         }
         else if (['single', 'multi'].includes(token)) {


### PR DESCRIPTION
This adds a label definition type for "Time", following the existing "Date" and "Date & Time".

Screenshots:

![image](https://github.com/user-attachments/assets/8b3c94be-0615-443b-b98d-40214f771c2e)
![image](https://github.com/user-attachments/assets/84ac781f-c4fb-4d01-9750-3085db73e7af)
