### PR TITLE
Remove resizer from backend log text area

### DIFF
--- a/src/public/app/widgets/type_widgets/content/backend_log.js
+++ b/src/public/app/widgets/type_widgets/content/backend_log.js
@@ -8,6 +8,7 @@ const TPL = `<div style="height: 100%; display: flex; flex-direction: column;">
             flex-grow: 1; 
             width: 100%;
             border: none;
+            resize: none;
         }   
     </style>
 


### PR DESCRIPTION
This hides the resizer since it wasn't working (and isn't necessary).
![image](https://github.com/user-attachments/assets/5a92c6bf-0916-4a43-bb14-6e75899cabaf)
