### PR TITLE
i18n: make duplicate notes suffix translatable

### DIFF
--- a/src/services/notes.ts
+++ b/src/services/notes.ts
@@ -923,8 +923,10 @@ function duplicateSubtree(origNoteId: string, newParentNoteId: string) {
 
     const res = duplicateSubtreeInner(origNote, origBranch, newParentNoteId, noteIdMapping);
 
-    if (!res.note.title.endsWith('(dup)')) {
-        res.note.title += " (dup)";
+    const duplicateNoteSuffix = t("notes.duplicate-note-suffix");
+
+    if (!res.note.title.endsWith(duplicateNoteSuffix) && !res.note.title.startsWith(duplicateNoteSuffix)) {
+        res.note.title = t("notes.duplicate-note-title", { noteTitle: res.note.title, duplicateNoteSuffix: duplicateNoteSuffix });
     }
 
     res.note.save();

--- a/translations/en/server.json
+++ b/translations/en/server.json
@@ -242,6 +242,8 @@
     "visible-launchers-title": "Visible Launchers"
   },
   "notes": {
-    "new-note": "New note"
+    "new-note": "New note",
+    "duplicate-note-suffix": "(dup)",
+    "duplicate-note-title": "{{ noteTitle }} {{ duplicateNoteSuffix }}"
   }
 }


### PR DESCRIPTION
Hello,

This PR makes the "(dup)" suffix for duplicated notes translatable.
Previously this was fully hardcoded as " (dup)", now we can translate it, using `notes.duplicate-note-suffix`.

I've also added support for RTL languages by allowing the translators to decide where the suffix should be placed:
For LTR languages it will be at the "right end" of the string, for RTL languages it will be at the "left end" of the string.
This is using `notes.duplicate-note-title`.

To keep the same functionality as before for RTL langs (where the suffix is only added once for a note, even if there are several clones), I expanded the `res.note.title` check to also check for `startsWith`.
Since majority of languages are LTR, I've kept the "endsWith" check as first check, so that we can make use of short-circuiting.

I did not update the existing translations with these new translation keys though – this way these will still keep the English translation until they get properly translated.

Closes #825 