### PR TITLE
i18n: improve translatability of database_backed_up_to string

### DIFF
--- a/src/public/app/widgets/type_widgets/options/backup.js
+++ b/src/public/app/widgets/type_widgets/options/backup.js
@@ -70,7 +70,7 @@ export default class BackupOptions extends OptionsWidget {
         this.$backupDatabaseButton.on('click', async () => {
             const {backupFile} = await server.post('database/backup-database');
 
-            toastService.showMessage(`${t('backup.database_backed_up_to')} ${backupFile}`, 10000);
+            toastService.showMessage(t('backup.database_backed_up_to', { backupFilePath: backupFile}), 10000);
 
             this.refresh();
         });

--- a/src/public/translations/cn/translation.json
+++ b/src/public/translations/cn/translation.json
@@ -1195,7 +1195,7 @@
     "existing_backups": "现有备份",
     "date-and-time": "日期和时间",
     "path": "路径",
-    "database_backed_up_to": "数据库已备份到",
+    "database_backed_up_to": "数据库已备份到 {{backupFilePath}}",
     "no_backup_yet": "尚无备份"
   },
   "etapi": {

--- a/src/public/translations/de/translation.json
+++ b/src/public/translations/de/translation.json
@@ -1183,7 +1183,7 @@
     "backup_now": "Jetzt sichern",
     "backup_database_now": "Jetzt Datenbank sichern",
     "existing_backups": "Vorhandene Backups",
-    "database_backed_up_to": "Die Datenbank wurde gesichert",
+    "database_backed_up_to": "Die Datenbank wurde gesichert unter {{backupFilePath}}",
     "no_backup_yet": "noch kein Backup"
   },
   "etapi": {

--- a/src/public/translations/en/translation.json
+++ b/src/public/translations/en/translation.json
@@ -1225,7 +1225,7 @@
     "existing_backups": "Existing backups",
     "date-and-time": "Date & time",
     "path": "Path",
-    "database_backed_up_to": "Database has been backed up to",
+    "database_backed_up_to": "Database has been backed up to {{backupFilePath}}",
     "no_backup_yet": "no backup yet"
   },
   "etapi": {

--- a/src/public/translations/es/translation.json
+++ b/src/public/translations/es/translation.json
@@ -1207,7 +1207,7 @@
     "existing_backups": "Copias de seguridad existentes",
     "date-and-time": "Fecha y hora",
     "path": "Ruta",
-    "database_backed_up_to": "Se ha realizado una copia de seguridad de la base de datos en",
+    "database_backed_up_to": "Se ha realizado una copia de seguridad de la base de datos en {{backupFilePath}}",
     "no_backup_yet": "no hay copia de seguridad todavía"
   },
   "etapi": {

--- a/src/public/translations/fr/translation.json
+++ b/src/public/translations/fr/translation.json
@@ -1184,7 +1184,7 @@
     "backup_now": "Sauvegarder maintenant",
     "backup_database_now": "Sauvegarder la base de données maintenant",
     "existing_backups": "Sauvegardes existantes",
-    "database_backed_up_to": "La base de données a été sauvegardée sur",
+    "database_backed_up_to": "La base de données a été sauvegardée sur {{backupFilePath}}",
     "no_backup_yet": "pas encore de sauvegarde"
   },
   "etapi": {

--- a/src/public/translations/ro/translation.json
+++ b/src/public/translations/ro/translation.json
@@ -252,7 +252,7 @@
     "backup_database_now": "Crează o copie a bazei de date acum",
     "backup_now": "Crează o copie de siguranță acum",
     "backup_recommendation": "Se recomandă a se păstra activată funcția de copii de siguranță, dar acest lucru poate face pornirea aplicației mai lentă pentru baze de date mai mari sau pentru dispozitive de stocare lente.",
-    "database_backed_up_to": "S-a creat o copie de siguranță a bazei de dată la",
+    "database_backed_up_to": "S-a creat o copie de siguranță a bazei de dată la {{backupFilePath}}",
     "enable_daily_backup": "Activează copia de siguranță zilnică",
     "enable_monthly_backup": "Activează copia de siguranță lunară",
     "enable_weekly_backup": "Activează copia de siguranță săptămânală",

--- a/src/public/translations/tw/translation.json
+++ b/src/public/translations/tw/translation.json
@@ -1195,7 +1195,7 @@
     "existing_backups": "現有備份",
     "date-and-time": "日期和時間",
     "path": "路徑",
-    "database_backed_up_to": "資料庫已備份到",
+    "database_backed_up_to": "資料庫已備份到 {{backupFilePath}}",
     "no_backup_yet": "尚無備份"
   },
   "etapi": {


### PR DESCRIPTION
Hello,

this PR improves translatability of the `backup.database_backed_up_to` message by moving the backupFile path into the translation string – this a) makes the string RTL translatable and b) adds more context for LTR languages as well.