### PR TITLE
chore: fix typo in protected_session_password dialog

### DIFF
--- a/src/public/app/widgets/dialogs/protected_session_password.js
+++ b/src/public/app/widgets/dialogs/protected_session_password.js
@@ -14,7 +14,7 @@ const TPL = `
             </div>
             <form class="protected-session-password-form">
                 <div class="modal-body">
-                    <label for="protected-session-password" class="col-form-label">${t("protected_session_password.form_label")}asbd</label>
+                    <label for="protected-session-password" class="col-form-label">${t("protected_session_password.form_label")}</label>
                     <input id="protected-session-password" class="form-control protected-session-password" type="password">
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
I've accidentally introduced those 4 letters at the end of the string, with my last commit :-)
Sorry!