### PR TITLE
refactor(session_secret): use existing randomSecureToken function

### DIFF
--- a/src/services/session_secret.ts
+++ b/src/services/session_secret.ts
@@ -1,9 +1,9 @@
 "use strict";
 
 import fs from "fs";
-import crypto from "crypto";
 import dataDir from "./data_dir.js";
 import log from "./log.js";
+import utils from "./utils.js"
 
 const sessionSecretPath = `${dataDir.TRILIUM_DATA_DIR}/session_secret.txt`;
 
@@ -11,14 +11,8 @@ let sessionSecret: string;
 
 const ENCODING = "ascii";
 
-function randomValueHex(len: number) {
-    return crypto.randomBytes(Math.ceil(len / 2))
-        .toString('hex') // convert to hexadecimal format
-        .slice(0, len).toUpperCase();   // return required number of characters
-}
-
 if (!fs.existsSync(sessionSecretPath)) {
-    sessionSecret = randomValueHex(64);
+    sessionSecret = utils.randomSecureToken(64).slice(0, 64);
 
     log.info("Generated session secret");
 


### PR DESCRIPTION
Hi,

this PR repalces the `randomValueHex` function (which is not used anywhere else across the codebase) with the already existing `randomSecureToken` function from the utils module for the creation of the session.

They both are using the `randomBytes` method of the crypto module.

This also improves secret security, as `randomSecureToken` uses Base64 and hence a much larger charset size than `randomValueHex` (which also unnecessarily was made even a bit more insecure, by having all characters UPPERCASED, so an even smaller charset size).

Some examples:

```
$ for i in $(<hashB64.txt); do echo "$i | $(echo $i | ent | head -1)"; done

XkPHvfhZISIS0OsfO6TzRbQkSdnTNLUZ0r+1qu9TD0CEm17isJ21tYUY5QjD/q7P | Entropy = 5.329759 bits per byte.
dGPMvn95YlRKOca65WMG+BgnMr94rl9Rh5Ac2gZQwBUrvrgJ+LGkoZ3UyghVFSfU | Entropy = 5.133530 bits per byte.
QkPieq6Q7zWnWddgSDEZFV6tVvGEBvQqMRlRbfbxCJUbh9tf47tRtzZCEjuS0oly | Entropy = 5.206682 bits per byte.
Bt0mAtgzbB4gcFbxdvjx/5d5/4fujhKLZKNweP3VkgdTLZCWoY90L17gLOAI3G6M | Entropy = 5.303062 bits per byte.
4J6mddl3QCn96aWzfhXaTGLQxF3WRHUihABGUl+Hng8FvsK8NBN9uO2V0UiMkrtC | Entropy = 5.395370 bits per byte.
JSsRWnyqix/zIDHbWBpqeCzv/Gm0FmWYXzzkI6Yl8nRMhcLc+c4F5AUs4s/zJmTr | Entropy = 5.231844 bits per byte.
LE66pEBu4HvGO+k9Z5oEf6dzj79tkA0D6A+iuuGcugjwjfnOWU0gojxfb39zILd6 | Entropy = 5.039686 bits per byte.
ymEHUcjsBqAQY8Tcpm3QYBABSUqsSlPXQTifwIQRjigj1Modi7RN7ryEpLUkoUJX | Entropy = 5.095219 bits per byte.
c/AQHlm75lMG9/aGCgdy0YsNclS2LG97PDpnibOqjjK4vDVpHT74betFrjvpUhNq | Entropy = 5.348915 bits per byte.
CDQRfJMYPS2JfX0+ebOW9wAIN2v0REHmRzNAXNrVx53lbzo3g+puXJSO4nf8x+ju | Entropy = 5.275763 bits per byte.
```


vs previously used secrets

```
DA00B0B76F686C86BD8C3F5F14E7649C7F05A3B00E724C011A889AD04491F62B | Entropy = 3.938397 bits per byte.
DCEB458061F12442558E5D753E64050F2FEEA31F8C505A23DEEA05E820186B6C | Entropy = 3.802707 bits per byte.
BB22E1348C91304C455952221EF5D03A79FCEBDF062283A9CBDDD1ED7D447541 | Entropy = 3.925496 bits per byte.
B3B12C0FE42981C4D4FBFEA53C59C042D4BB2B41935877BC36D2025FB57E8B39 | Entropy = 3.885335 bits per byte.
04A8B12F33D2C54C39CBA3E0C740BA06B05127AD945D945F9DFB185F8D848356 | Entropy = 3.951944 bits per byte.
D8482D98FF959A3513C9B7A20B2673C1559C1177405C5A907F3F604455E0B525 | Entropy = 3.896014 bits per byte.
BB8E2F63499F5784E17CC917067D9853C4F79FB8702FE2D2857E871FF66633B3 | Entropy = 3.852987 bits per byte.
47935A3736BB22CC1DB5BF439A571759A4579F5C35AF798CCE7267D28645C544 | Entropy = 3.771938 bits per byte.
5130CD305A37ABE22885C52020653DF08CC3D23A0752EC95C0D54FEC1D5E1ADF | Entropy = 3.766579 bits per byte.
94FAFB0A15E7012B67907EBDFABCB3817495AEF7FDA10DF6615C1128E818A650 | Entropy = 3.909164 bits per byte.
```

This will only affect newly created newly created session secrets only.
