### PR TITLE
refactor(services): use Set instead of Arrays for faster lookups

### DIFF
--- a/src/services/attributes.ts
+++ b/src/services/attributes.ts
@@ -9,7 +9,7 @@ import BUILTIN_ATTRIBUTES from "./builtin_attributes.js";
 import BNote from "../becca/entities/bnote.js";
 import { AttributeRow } from '../becca/entities/rows.js';
 
-const ATTRIBUTE_TYPES = ['label', 'relation'];
+const ATTRIBUTE_TYPES = new Set(['label', 'relation']);
 
 function getNotesWithLabel(name: string, value?: string): BNote[] {
     const query = attributeFormatter.formatAttrForSearch({type: 'label', name, value}, value !== undefined);
@@ -99,7 +99,7 @@ function getAttributeNames(type: string, nameLike: string) {
 }
 
 function isAttributeType(type: string): boolean {
-    return ATTRIBUTE_TYPES.includes(type);
+    return ATTRIBUTE_TYPES.has(type);
 }
 
 function isAttributeDangerous(type: string, name: string): boolean {

--- a/src/services/search/expressions/note_content_fulltext.ts
+++ b/src/services/search/expressions/note_content_fulltext.ts
@@ -13,7 +13,7 @@ import utils from "../../utils.js";
 import sql from "../../sql.js";
 
 
-const ALLOWED_OPERATORS = ['=', '!=', '*=*', '*=', '=*', '%='];
+const ALLOWED_OPERATORS = new Set(['=', '!=', '*=*', '*=', '=*', '%=']);
 
 const cachedRegexes: Record<string, RegExp> = {};
 
@@ -50,8 +50,8 @@ class NoteContentFulltextExp extends Expression {
     }
 
     execute(inputNoteSet: NoteSet, executionContext: {}, searchContext: SearchContext) {
-        if (!ALLOWED_OPERATORS.includes(this.operator)) {
-            searchContext.addError(`Note content can be searched only with operators: ${ALLOWED_OPERATORS.join(", ")}, operator ${this.operator} given.`);
+        if (!ALLOWED_OPERATORS.has(this.operator)) {
+            searchContext.addError(`Note content can be searched only with operators: ${Array.from(ALLOWED_OPERATORS).join(", ")}, operator ${this.operator} given.`);
 
             return inputNoteSet;
         }

--- a/src/services/search/services/parse.ts
+++ b/src/services/search/services/parse.ts
@@ -44,7 +44,7 @@ function getFulltext(_tokens: TokenData[], searchContext: SearchContext) {
     }
 }
 
-const OPERATORS = [
+const OPERATORS = new Set([
     "=",
     "!=",
     "*=*",
@@ -55,14 +55,14 @@ const OPERATORS = [
     "<",
     "<=",
     "%="
-];
+]);
 
 function isOperator(token: TokenData) {
     if (Array.isArray(token)) {
         return false;
     }
 
-    return OPERATORS.includes(token.token);
+    return OPERATORS.has(token.token);
 }
 
 function getExpression(tokens: TokenData[], searchContext: SearchContext, level = 0) {

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -152,19 +152,19 @@ function getContentDisposition(filename: string) {
     return `file; filename="${sanitizedFilename}"; filename*=UTF-8''${sanitizedFilename}`;
 }
 
-const STRING_MIME_TYPES = [
+const STRING_MIME_TYPES = new Set([
     "application/javascript",
     "application/x-javascript",
     "application/json",
     "application/x-sql",
     "image/svg+xml"
-];
+]);
 
 function isStringNote(type: string | undefined, mime: string) {
     // render and book are string note in the sense that they are expected to contain empty string
     return (type && ["text", "code", "relationMap", "search", "render", "book", "mermaid", "canvas"].includes(type))
         || mime.startsWith('text/')
-        || STRING_MIME_TYPES.includes(mime);
+        || STRING_MIME_TYPES.has(mime);
 }
 
 function quoteRegex(url: string) {


### PR DESCRIPTION
Hi,

this PR aims to replace a handful of lookups via Array's `include` method with lookups via Set's `has` method.
These are a lot faster, as the `include` method is doing a linear search, whereas Set's `has` implementation is a hash table or a search tree according to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) (I guess it depends on the used JavaScript runtime)

I did some very basic benchmark ( I can provide the code if desired) and got the following results for a 1000 test runs of the "worst case" for Arrays (i.e. the value that we are looking for is at the end of the Array):

```
Suite: Compare Set 'has' vs Array 'includes'
============================================

✔ Set has '%=           217.347.485 ops/sec
✔ Array includes '%='    65.295.207 ops/sec

   Set has '%=              +232,87%   (217.347.485 ops/sec)   (avg: 4ns)
   Array includes '%=' (#)        0%   (65.295.207 ops/sec)   (avg: 15ns)

┌─────────────────────┬────────────────────────────────────────────────────┐
│ Set has '%=         │ ██████████████████████████████████████████████████ │
├─────────────────────┼────────────────────────────────────────────────────┤
│ Array includes '%=' │ ███████████████                                    │
└─────────────────────┴────────────────────────────────────────────────────┘
```
 But even with the best case scenario for an Array (i.e. the value is first in the list) Set was faster.

I've only picked some low hanging fruits here. There are a few more places where this could become useful, however I think this should probably be part of later/other  refactorings of specific services, as it kinda requires to have some sort of centrally defined "enums" before.