### PR TITLE
refactor(sanitizeAttributeName): simplify function and export

### DIFF
--- a/spec-es6/sanitize_attribute_name.spec.ts
+++ b/spec-es6/sanitize_attribute_name.spec.ts
@@ -1,0 +1,43 @@
+import sanitizeAttributeName from "../src/services/sanitize_attribute_name"
+import { describe, it, execute, expect } from "./mini_test";
+
+// fn value, expected value
+const testCases: [fnValue: string, expectedValue: string][] = [
+  ["testName", "testName"],
+  ["test_name", "test_name"],
+  ["test with space", "test_with_space"],
+  ["test:with:colon", "test:with:colon"],
+
+  // numbers
+  ["123456", "123456"],
+  ["123:456", "123:456"],
+  ["123456 abc", "123456_abc"],
+
+  // non-latin characters
+  ["ε", "ε"],
+  ["attribute ε", "attribute_ε"],
+
+
+  // special characters
+  ["test/name", "test_name"],
+  ["test%name", "test_name"],
+  ["\/", "_"],
+
+  // empty string
+  ["", "unnamed"],
+]
+
+
+
+describe("sanitizeAttributeName unit tests", () => {
+
+  testCases.forEach(testCase => {
+    return it(`'${testCase[0]}' should return '${testCase[1]}'`, () => {
+      const [value, expected] = testCase;
+      const actual = sanitizeAttributeName(value);
+      expect(actual).toEqual(expected);
+    })
+  })
+})
+
+execute()

--- a/src/becca/entities/battribute.ts
+++ b/src/becca/entities/battribute.ts
@@ -174,7 +174,7 @@ class BAttribute extends AbstractBeccaEntity<BAttribute> {
             this.validate();
         }
 
-        this.name = sanitizeAttributeName.sanitizeAttributeName(this.name);
+        this.name = sanitizeAttributeName(this.name);
 
         if (!this.value) {
             // null value isn't allowed

--- a/src/routes/api/sender.ts
+++ b/src/routes/api/sender.ts
@@ -3,7 +3,7 @@
 import imageType from "image-type";
 import imageService from "../../services/image.js";
 import noteService from "../../services/notes.js";
-import sanitize_attribute_name from "../../services/sanitize_attribute_name.js";
+import sanitizeAttributeName from "../../services/sanitize_attribute_name.js";
 import specialNotesService from "../../services/special_notes.js";
 import { Request } from 'express';
 
@@ -44,7 +44,7 @@ async function uploadImage(req: Request) {
         const labels = JSON.parse(labelsStr);
 
         for (const { name, value } of labels) {
-            note.setLabel(sanitize_attribute_name.sanitizeAttributeName(name), value);
+            note.setLabel(sanitizeAttributeName(name), value);
         }
     }
 
@@ -73,7 +73,7 @@ function saveNote(req: Request) {
 
     if (req.body.labels) {
         for (const { name, value } of req.body.labels) {
-            note.setLabel(sanitize_attribute_name.sanitizeAttributeName(name), value);
+            note.setLabel(sanitizeAttributeName(name), value);
         }
     }
 

--- a/src/services/consistency_checks.ts
+++ b/src/services/consistency_checks.ts
@@ -754,7 +754,7 @@ class ConsistencyChecks {
         const attrNames = sql.getColumn<string>(`SELECT DISTINCT name FROM attributes`);
 
         for (const origName of attrNames) {
-            const fixedName = sanitizeAttributeName.sanitizeAttributeName(origName);
+            const fixedName = sanitizeAttributeName(origName);
 
             if (fixedName !== origName) {
                 if (this.autoFix) {

--- a/src/services/import/enex.ts
+++ b/src/services/import/enex.ts
@@ -151,7 +151,7 @@ function importEnex(taskContext: TaskContext, file: File, parentNote: BNote): Pr
                 labelName = 'pageUrl';
             }
 
-            labelName = sanitizeAttributeName.sanitizeAttributeName(labelName || "");
+            labelName = sanitizeAttributeName(labelName || "");
 
             if (note.attributes) {
                 note.attributes.push({
@@ -202,7 +202,7 @@ function importEnex(taskContext: TaskContext, file: File, parentNote: BNote): Pr
             } else if (currentTag === 'tag' && note.attributes) {
                 note.attributes.push({
                     type: 'label',
-                    name: sanitizeAttributeName.sanitizeAttributeName(text),
+                    name: sanitizeAttributeName(text),
                     value: ''
                 })
             }

--- a/src/services/sanitize_attribute_name.ts
+++ b/src/services/sanitize_attribute_name.ts
@@ -1,13 +1,8 @@
 export default function sanitizeAttributeName(origName: string) {
-    let fixedName: string;
-
-    if (origName === '') {
-        fixedName = "unnamed";
-    }
-    else {
+    const fixedName = (origName === '')
+        ? "unnamed"
+        : origName.replace(/[^\p{L}\p{N}_:]/ug, "_");
         // any not allowed character should be replaced with underscore
-        fixedName = origName.replace(/[^\p{L}\p{N}_:]/ug, "_");
-    }
 
     return fixedName;
 }

--- a/src/services/sanitize_attribute_name.ts
+++ b/src/services/sanitize_attribute_name.ts
@@ -1,4 +1,4 @@
-function sanitizeAttributeName(origName: string) {
+export default function sanitizeAttributeName(origName: string) {
     let fixedName: string;
 
     if (origName === '') {
@@ -11,8 +11,3 @@ function sanitizeAttributeName(origName: string) {
 
     return fixedName;
 }
-
-
-export default {
-    sanitizeAttributeName
-};


### PR DESCRIPTION
Hi,


I've simplified the sanitizeAttributeNames function and updated the way it gets exported: there is no need to have the function wrapped in an object, just export it directly and save some typing :-)
I also created a very basic test/spec file using the provided test runner.