### PR TITLE
refactor(utils): add isMac and isWindows util functions

### DIFF
--- a/src/services/keyboard_actions.ts
+++ b/src/services/keyboard_actions.ts
@@ -2,11 +2,11 @@
 
 import optionService from "./options.js";
 import log from "./log.js";
-import { isElectron as getIsElectron } from "./utils.js";
+import { isElectron as getIsElectron, isMac as getIsMac } from "./utils.js";
 import { KeyboardShortcut } from './keyboard_actions_interface.js';
 import { t } from "i18next";
 
-const isMac = process.platform === "darwin";
+const isMac = getIsMac();
 const isElectron = getIsElectron();
 
 function getDefaultKeyboardActions() {

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -4,6 +4,7 @@ import { Request, Response } from "express";
 import fs from "fs";
 import dataDir from "./data_dir.js";
 import cls from "./cls.js";
+import { isWindows } from "./utils.js";
 
 if (!fs.existsSync(dataDir.LOG_DIR)) {
     fs.mkdirSync(dataDir.LOG_DIR, 0o700);
@@ -16,7 +17,7 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
-const NEW_LINE = process.platform === "win32" ? '\r\n' : '\n';
+const NEW_LINE = isWindows() ? '\r\n' : '\n';
 
 let todaysMidnight!: Date;
 

--- a/src/services/options_init.ts
+++ b/src/services/options_init.ts
@@ -1,7 +1,7 @@
 import optionService from "./options.js";
 import type { OptionMap } from "./options.js";
 import appInfo from "./app_info.js";
-import { randomSecureToken } from "./utils.js";
+import { randomSecureToken, isWindows } from "./utils.js";
 import log from "./log.js";
 import dateUtils from "./date_utils.js";
 import keyboardActions from "./keyboard_actions.js";
@@ -72,7 +72,7 @@ const defaultOptions: DefaultOption[] = [
     { name: 'revisionSnapshotTimeInterval', value: '600', isSynced: true },
     { name: 'revisionSnapshotNumberLimit', value: '-1', isSynced: true },
     { name: 'protectedSessionTimeout', value: '600', isSynced: true },
-    { name: 'zoomFactor', value: process.platform === "win32" ? '0.9' : '1.0', isSynced: false },
+    { name: 'zoomFactor', value: isWindows() ? '0.9' : '1.0', isSynced: false },
     { name: 'overrideThemeFonts', value: 'false', isSynced: false },
     { name: 'mainFontFamily', value: 'theme', isSynced: false },
     { name: 'mainFontSize', value: '100', isSynced: false },

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -332,6 +332,14 @@ export function getResourceDir() {
     }
 }
 
+export function isMac() {
+  return process.platform === "darwin";
+}
+
+export function isWindows() {
+  return process.platform === "win32";
+}
+
 export default {
     randomSecureToken,
     randomString,
@@ -365,5 +373,7 @@ export default {
     hashedBlobId,
     toMap,
     isString,
-    getResourceDir
+    getResourceDir,
+    isMac,
+    isWindows
 };

--- a/src/services/window.ts
+++ b/src/services/window.ts
@@ -9,6 +9,7 @@ import cls from "./cls.js";
 import keyboardActionsService from "./keyboard_actions.js";
 import remoteMain from "@electron/remote/main/index.js";
 import { App, BrowserWindow, BrowserWindowConstructorOptions, WebContents, ipcMain } from 'electron';
+import { isMac, isWindows } from "./utils.js";
 
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -115,14 +116,11 @@ async function createMainWindow(app: App) {
 function getWindowExtraOpts() {
     const extraOpts: Partial<BrowserWindowConstructorOptions> = {};
 
-    const isMac = (process.platform === "darwin");
-    const isWindows = (process.platform === "win32");
-
     if (!optionService.getOptionBool('nativeTitleBarVisible')) {
-        if (isMac) {
+        if (isMac()) {
             extraOpts.titleBarStyle = "hiddenInset";
             extraOpts.titleBarOverlay = true;
-        } else if (isWindows) {
+        } else if (isWindows()) {
             extraOpts.titleBarStyle = "hidden";
             extraOpts.titleBarOverlay = true;
         } else {
@@ -132,7 +130,7 @@ function getWindowExtraOpts() {
     }
 
     // Window effects (Mica)
-    if (optionService.getOptionBool('backgroundEffects') && isWindows) {
+    if (optionService.getOptionBool('backgroundEffects') && isWindows()) {
         extraOpts.backgroundMaterial = "auto";
     }
 


### PR DESCRIPTION
Hi,

this PR aims to consolidate isMac and isWindows functions into single central functions in utils, so that there is only place that needs to be maintained in the future.
(Addmittedly: it of course will be unlikely that the process.platform values will change very soon, but this still makes it a bit cleaner than having several `process.platform === "` comparisons across the codebase).

I only did this on the server side of things, I did not touch the "frontend" part, which already contains its own isMac function in its utils module