### PR TITLE
refactor(data_dir): simplify logic and make code robust and testable

### DIFF
--- a/spec-es6/data_dir.spec.ts
+++ b/spec-es6/data_dir.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, execute, expect } from "./mini_test.ts";
+
+import { getPlatformAppDataDir } from "../src/services/data_dir.ts"
+
+
+
+describe("data_dir.ts unit tests", () => {
+
+  describe("#getPlatformAppDataDir", () => {
+
+    type TestCaseGetPlatformAppDataDir = [
+      description: string,
+      fnValue: Parameters<typeof getPlatformAppDataDir>, 
+      expectedValueFn: (val: ReturnType<typeof getPlatformAppDataDir>) => boolean
+    ]
+    const testCases: TestCaseGetPlatformAppDataDir[] = [
+
+      [
+        "w/ unsupported OS it should return 'null'",
+        ["aix", undefined], 
+        (val) => val === null 
+      ],
+
+      [
+        "w/ win32 and no APPDATA set it should return 'null'",
+        ["win32", undefined],
+        (val) => val === null
+      ],
+
+      [
+        "w/ win32 and set APPDATA it should return set 'APPDATA'",
+        ["win32", "AppData"],
+        (val) => val === "AppData"
+      ],
+
+      [
+        "w/ linux it should return '/.local/share'",
+        ["linux", undefined],
+        (val) => val !== null && val.endsWith("/.local/share")
+      ],
+
+      [
+        "w/ linux and wrongly set APPDATA it should ignore APPDATA and return /.local/share",
+        ["linux", "FakeAppData"],
+        (val) => val !== null && val.endsWith("/.local/share")
+      ],
+
+      [
+        "w/ darwin it should return /Library/Application Support",
+        ["darwin", undefined],
+        (val) => val !== null && val.endsWith("/Library/Application Support")
+      ],
+    ];
+
+      testCases.forEach(testCase => {
+        const [testDescription, value, isExpected] = testCase;
+        return it(testDescription, () => {
+          const actual = getPlatformAppDataDir(...value);
+          const result = isExpected(actual);
+          expect(result).toBeTruthy()
+
+        })
+      })
+
+
+  })
+
+  describe("#getTriliumDataDir", () => {
+    // TODO
+  })
+
+  describe("#getDataDirs", () => {
+    // TODO
+  })
+
+});
+
+execute()

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -15,6 +15,52 @@ import { join as pathJoin} from "path";
 const DIR_NAME = "trilium-data";
 const FOLDER_PERMISSIONS = 0o700;
 
+export function getTriliumDataDir(dataDirName: string) {
+  // case A
+  if (process.env.TRILIUM_DATA_DIR) {
+      createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
+      return process.env.TRILIUM_DATA_DIR;
+  }
+
+  // case B
+  const homePath = pathJoin(os.homedir(), dataDirName);
+  if (fs.existsSync(homePath)) {
+      return homePath;
+  }
+
+  // case C
+  const platformAppDataDir = getPlatformAppDataDir(os.platform(), process.env.APPDATA);
+  if (platformAppDataDir && fs.existsSync(platformAppDataDir)) {
+      const appDataDirPath = pathJoin(platformAppDataDir, dataDirName);
+      createDirIfNotExisting(appDataDirPath);
+      return appDataDirPath;
+  }
+
+  // case D
+  createDirIfNotExisting(homePath);
+  return homePath;
+}
+
+export function getDataDirs(TRILIUM_DATA_DIR: string) {
+  const dataDirs = {
+      "TRILIUM_DATA_DIR":
+          TRILIUM_DATA_DIR,
+      "DOCUMENT_PATH":
+          process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db"),
+      "BACKUP_DIR":
+          process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup"),
+      "LOG_DIR":
+          process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log"),
+      "ANONYMIZED_DB_DIR":
+          process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db"),
+      "CONFIG_INI_PATH":
+          process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini")
+  } as const
+
+  Object.freeze(dataDirs);
+  return dataDirs;
+}
+
 export function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, ENV_APPDATA_DIR: string | undefined = process.env.APPDATA) {
 
     switch(true) {
@@ -40,52 +86,7 @@ function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOL
     }
 }
 
-export function getTriliumDataDir(dataDirName: string) {
-    // case A
-    if (process.env.TRILIUM_DATA_DIR) {
-        createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
-        return process.env.TRILIUM_DATA_DIR;
-    }
 
-    // case B
-    const homePath = pathJoin(os.homedir(), dataDirName);
-    if (fs.existsSync(homePath)) {
-        return homePath;
-    }
-
-    // case C
-    const platformAppDataDir = getPlatformAppDataDir(os.platform(), process.env.APPDATA);
-    if (platformAppDataDir && fs.existsSync(platformAppDataDir)) {
-        const appDataDirPath = pathJoin(platformAppDataDir, dataDirName);
-        createDirIfNotExisting(appDataDirPath);
-        return appDataDirPath;
-    }
-
-    // case D
-    createDirIfNotExisting(homePath);
-    return homePath;
-}
-
-export function getDataDirs(TRILIUM_DATA_DIR: string) {
-    const dataDirs = {
-        "TRILIUM_DATA_DIR":
-            TRILIUM_DATA_DIR,
-        "DOCUMENT_PATH":
-            process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db"),
-        "BACKUP_DIR":
-            process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup"),
-        "LOG_DIR":
-            process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log"),
-        "ANONYMIZED_DB_DIR":
-            process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db"),
-        "CONFIG_INI_PATH":
-            process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini")
-    } as const
-
-    Object.freeze(dataDirs);
-    return dataDirs;
-
-}
 
 const TRILIUM_DATA_DIR = getTriliumDataDir(DIR_NAME);
 const dataDirs = getDataDirs(TRILIUM_DATA_DIR);

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -10,60 +10,53 @@
 
 import os from "os";
 import fs from "fs";
-import { join as pathJoin} from "path";
+import { join as pathJoin } from "path";
 
 const DIR_NAME = "trilium-data";
 const FOLDER_PERMISSIONS = 0o700;
 
 export function getTriliumDataDir(dataDirName: string) {
-  // case A
-  if (process.env.TRILIUM_DATA_DIR) {
-      createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
-      return process.env.TRILIUM_DATA_DIR;
-  }
+    // case A
+    if (process.env.TRILIUM_DATA_DIR) {
+        createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
+        return process.env.TRILIUM_DATA_DIR;
+    }
 
-  // case B
-  const homePath = pathJoin(os.homedir(), dataDirName);
-  if (fs.existsSync(homePath)) {
-      return homePath;
-  }
+    // case B
+    const homePath = pathJoin(os.homedir(), dataDirName);
+    if (fs.existsSync(homePath)) {
+        return homePath;
+    }
 
-  // case C
-  const platformAppDataDir = getPlatformAppDataDir(os.platform(), process.env.APPDATA);
-  if (platformAppDataDir && fs.existsSync(platformAppDataDir)) {
-      const appDataDirPath = pathJoin(platformAppDataDir, dataDirName);
-      createDirIfNotExisting(appDataDirPath);
-      return appDataDirPath;
-  }
+    // case C
+    const platformAppDataDir = getPlatformAppDataDir(os.platform(), process.env.APPDATA);
+    if (platformAppDataDir && fs.existsSync(platformAppDataDir)) {
+        const appDataDirPath = pathJoin(platformAppDataDir, dataDirName);
+        createDirIfNotExisting(appDataDirPath);
+        return appDataDirPath;
+    }
 
-  // case D
-  createDirIfNotExisting(homePath);
-  return homePath;
+    // case D
+    createDirIfNotExisting(homePath);
+    return homePath;
 }
 
 export function getDataDirs(TRILIUM_DATA_DIR: string) {
-  const dataDirs = {
-      "TRILIUM_DATA_DIR":
-          TRILIUM_DATA_DIR,
-      "DOCUMENT_PATH":
-          process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db"),
-      "BACKUP_DIR":
-          process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup"),
-      "LOG_DIR":
-          process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log"),
-      "ANONYMIZED_DB_DIR":
-          process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db"),
-      "CONFIG_INI_PATH":
-          process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini")
-  } as const
+    const dataDirs = {
+        TRILIUM_DATA_DIR: TRILIUM_DATA_DIR,
+        DOCUMENT_PATH: process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db"),
+        BACKUP_DIR: process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup"),
+        LOG_DIR: process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log"),
+        ANONYMIZED_DB_DIR: process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db"),
+        CONFIG_INI_PATH: process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini")
+    } as const;
 
-  Object.freeze(dataDirs);
-  return dataDirs;
+    Object.freeze(dataDirs);
+    return dataDirs;
 }
 
 export function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, ENV_APPDATA_DIR: string | undefined = process.env.APPDATA) {
-
-    switch(true) {
+    switch (true) {
         case platform === "win32" && !!ENV_APPDATA_DIR:
             return ENV_APPDATA_DIR;
 
@@ -77,7 +70,6 @@ export function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, 
             // if OS is not recognized
             return null;
     }
-
 }
 
 function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOLDER_PERMISSIONS) {
@@ -85,8 +77,6 @@ function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOL
         fs.mkdirSync(path, permissionMode);
     }
 }
-
-
 
 const TRILIUM_DATA_DIR = getTriliumDataDir(DIR_NAME);
 const dataDirs = getDataDirs(TRILIUM_DATA_DIR);

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -2,37 +2,37 @@
 
 /*
  * This file resolves trilium data path in this order of priority:
- * - if TRILIUM_DATA_DIR environment variable exists, then its value is used as the path
- * - if "trilium-data" dir exists directly in the home dir, then it is used
- * - based on OS convention, if the "app data directory" exists, we'll use or create "trilium-data" directory there
- * - as a fallback if the previous step fails, we'll use home dir
+ * - case A) if TRILIUM_DATA_DIR environment variable exists, then its value is used as the path
+ * - case B) if "trilium-data" dir exists directly in the home dir, then it is used
+ * - case C) based on OS convention, if the "app data directory" exists, we'll use or create "trilium-data" directory there
+ * - case D) as a fallback if the previous step fails, we'll use home dir
  */
 
 import os from "os";
 import fs from "fs";
 import { join as pathJoin} from "path";
 
-function getAppDataDir() {
-    let appDataDir = os.homedir(); // fallback if OS is not recognized
-
-    if (os.platform() === "win32" && process.env.APPDATA) {
-        appDataDir = process.env.APPDATA;
-    } else if (os.platform() === "linux") {
-        appDataDir = `${os.homedir()}/.local/share`;
-    } else if (os.platform() === "darwin") {
-        appDataDir = `${os.homedir()}/Library/Application Support`;
-    }
-
-    if (!fs.existsSync(appDataDir)) {
-        // expected app data path doesn't exist, let's use fallback
-        appDataDir = os.homedir();
-    }
-
-    return appDataDir;
-}
-
 const DIR_NAME = "trilium-data";
 const FOLDER_PERMISSIONS = 0o700;
+
+function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, ENV_APPDATA_DIR: string | undefined = process.env.APPDATA) {
+
+    switch(true) {
+        case platform === "win32" && !!ENV_APPDATA_DIR:
+            return ENV_APPDATA_DIR;
+
+        case platform === "linux":
+            return `${os.homedir()}/.local/share`;
+
+        case platform === "darwin":
+            return `${os.homedir()}/Library/Application Support`;
+
+        default:
+            // if OS is not recognized
+            return null;
+    }
+
+}
 
 function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOLDER_PERMISSIONS) {
   if (!fs.existsSync(path)) {
@@ -41,20 +41,29 @@ function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOL
 }
 
 function getTriliumDataDir() {
+    // case A
     if (process.env.TRILIUM_DATA_DIR) {
         createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
         return process.env.TRILIUM_DATA_DIR;
     }
 
+    // case B
     const homePath = pathJoin(os.homedir(), DIR_NAME);
     if (fs.existsSync(homePath)) {
         return homePath;
     }
 
-    const appDataPath = pathJoin(getAppDataDir(), DIR_NAME);
-    createDirIfNotExisting(appDataPath);
+    // case C
+    const platformAppDataDir = getPlatformAppDataDir(os.platform(), process.env.APPDATA);
+    if (platformAppDataDir && fs.existsSync(platformAppDataDir)) {
+        const appDataDirPath = pathJoin(platformAppDataDir, DIR_NAME);
+        createDirIfNotExisting(appDataDirPath);
+        return appDataDirPath;
+    }
 
-    return appDataPath;
+    // case D
+    createDirIfNotExisting(homePath);
+    return homePath;
 }
 
 const TRILIUM_DATA_DIR = getTriliumDataDir();

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -66,19 +66,28 @@ function getTriliumDataDir() {
     return homePath;
 }
 
+function getDataDirs(TRILIUM_DATA_DIR: string) {
+    const dataDirs = {
+        "TRILIUM_DATA_DIR":
+            TRILIUM_DATA_DIR,
+        "DOCUMENT_PATH":
+            process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db"),
+        "BACKUP_DIR":
+            process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup"),
+        "LOG_DIR":
+            process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log"),
+        "ANONYMIZED_DB_DIR":
+            process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db"),
+        "CONFIG_INI_PATH":
+            process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini")
+    } as const
+
+    Object.freeze(dataDirs);
+    return dataDirs;
+
+}
+
 const TRILIUM_DATA_DIR = getTriliumDataDir();
+const dataDirs = getDataDirs(TRILIUM_DATA_DIR);
 
-const DOCUMENT_PATH = process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db");
-const BACKUP_DIR = process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup");
-const LOG_DIR = process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log");
-const ANONYMIZED_DB_DIR = process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db");
-const CONFIG_INI_PATH = process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini");
-
-export default {
-    TRILIUM_DATA_DIR,
-    DOCUMENT_PATH,
-    BACKUP_DIR,
-    LOG_DIR,
-    ANONYMIZED_DB_DIR,
-    CONFIG_INI_PATH
-};
+export default dataDirs;

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -10,7 +10,7 @@
 
 import os from "os";
 import fs from "fs";
-import path from "path";
+import { join as pathJoin} from "path";
 
 function getAppDataDir() {
     let appDataDir = os.homedir(); // fallback if OS is not recognized
@@ -46,27 +46,24 @@ function getTriliumDataDir() {
         return process.env.TRILIUM_DATA_DIR;
     }
 
-    const homePath = os.homedir() + path.sep + DIR_NAME;
-
+    const homePath = pathJoin(os.homedir(), DIR_NAME);
     if (fs.existsSync(homePath)) {
         return homePath;
     }
 
-    const appDataPath = getAppDataDir() + path.sep + DIR_NAME;
-
+    const appDataPath = pathJoin(getAppDataDir(), DIR_NAME);
     createDirIfNotExisting(appDataPath);
 
     return appDataPath;
 }
 
 const TRILIUM_DATA_DIR = getTriliumDataDir();
-const DIR_SEP = TRILIUM_DATA_DIR + path.sep;
 
-const DOCUMENT_PATH = process.env.TRILIUM_DOCUMENT_PATH || `${DIR_SEP}document.db`;
-const BACKUP_DIR = process.env.TRILIUM_BACKUP_DIR || `${DIR_SEP}backup`;
-const LOG_DIR = process.env.TRILIUM_LOG_DIR || `${DIR_SEP}log`;
-const ANONYMIZED_DB_DIR = process.env.TRILIUM_ANONYMIZED_DB_DIR || `${DIR_SEP}anonymized-db`;
-const CONFIG_INI_PATH = process.env.TRILIUM_CONFIG_INI_PATH || `${DIR_SEP}config.ini`;
+const DOCUMENT_PATH = process.env.TRILIUM_DOCUMENT_PATH || pathJoin(TRILIUM_DATA_DIR, "document.db");
+const BACKUP_DIR = process.env.TRILIUM_BACKUP_DIR || pathJoin(TRILIUM_DATA_DIR, "backup");
+const LOG_DIR = process.env.TRILIUM_LOG_DIR || pathJoin(TRILIUM_DATA_DIR, "log");
+const ANONYMIZED_DB_DIR = process.env.TRILIUM_ANONYMIZED_DB_DIR || pathJoin(TRILIUM_DATA_DIR, "anonymized-db");
+const CONFIG_INI_PATH = process.env.TRILIUM_CONFIG_INI_PATH || pathJoin(TRILIUM_DATA_DIR, "config.ini");
 
 export default {
     TRILIUM_DATA_DIR,

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -35,9 +35,9 @@ function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, ENV_APP
 }
 
 function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOLDER_PERMISSIONS) {
-  if (!fs.existsSync(path)) {
-    fs.mkdirSync(path, permissionMode);
-  }
+    if (!fs.existsSync(path)) {
+        fs.mkdirSync(path, permissionMode);
+    }
 }
 
 function getTriliumDataDir() {

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -34,13 +34,15 @@ function getAppDataDir() {
 const DIR_NAME = "trilium-data";
 const FOLDER_PERMISSIONS = 0o700;
 
+function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOLDER_PERMISSIONS) {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path, permissionMode);
+  }
+}
 
 function getTriliumDataDir() {
     if (process.env.TRILIUM_DATA_DIR) {
-        if (!fs.existsSync(process.env.TRILIUM_DATA_DIR)) {
-            fs.mkdirSync(process.env.TRILIUM_DATA_DIR, FOLDER_PERMISSIONS);
-        }
-
+        createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
         return process.env.TRILIUM_DATA_DIR;
     }
 
@@ -52,9 +54,7 @@ function getTriliumDataDir() {
 
     const appDataPath = getAppDataDir() + path.sep + DIR_NAME;
 
-    if (!fs.existsSync(appDataPath)) {
-        fs.mkdirSync(appDataPath, FOLDER_PERMISSIONS);
-    }
+    createDirIfNotExisting(appDataPath);
 
     return appDataPath;
 }

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -15,7 +15,7 @@ import { join as pathJoin} from "path";
 const DIR_NAME = "trilium-data";
 const FOLDER_PERMISSIONS = 0o700;
 
-function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, ENV_APPDATA_DIR: string | undefined = process.env.APPDATA) {
+export function getPlatformAppDataDir(platform: ReturnType<typeof os.platform>, ENV_APPDATA_DIR: string | undefined = process.env.APPDATA) {
 
     switch(true) {
         case platform === "win32" && !!ENV_APPDATA_DIR:
@@ -40,7 +40,7 @@ function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOL
     }
 }
 
-function getTriliumDataDir() {
+export function getTriliumDataDir() {
     // case A
     if (process.env.TRILIUM_DATA_DIR) {
         createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
@@ -66,7 +66,7 @@ function getTriliumDataDir() {
     return homePath;
 }
 
-function getDataDirs(TRILIUM_DATA_DIR: string) {
+export function getDataDirs(TRILIUM_DATA_DIR: string) {
     const dataDirs = {
         "TRILIUM_DATA_DIR":
             TRILIUM_DATA_DIR,

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -40,7 +40,7 @@ function createDirIfNotExisting(path: fs.PathLike, permissionMode: fs.Mode = FOL
     }
 }
 
-export function getTriliumDataDir() {
+export function getTriliumDataDir(dataDirName: string) {
     // case A
     if (process.env.TRILIUM_DATA_DIR) {
         createDirIfNotExisting(process.env.TRILIUM_DATA_DIR);
@@ -48,7 +48,7 @@ export function getTriliumDataDir() {
     }
 
     // case B
-    const homePath = pathJoin(os.homedir(), DIR_NAME);
+    const homePath = pathJoin(os.homedir(), dataDirName);
     if (fs.existsSync(homePath)) {
         return homePath;
     }
@@ -56,7 +56,7 @@ export function getTriliumDataDir() {
     // case C
     const platformAppDataDir = getPlatformAppDataDir(os.platform(), process.env.APPDATA);
     if (platformAppDataDir && fs.existsSync(platformAppDataDir)) {
-        const appDataDirPath = pathJoin(platformAppDataDir, DIR_NAME);
+        const appDataDirPath = pathJoin(platformAppDataDir, dataDirName);
         createDirIfNotExisting(appDataDirPath);
         return appDataDirPath;
     }
@@ -87,7 +87,7 @@ export function getDataDirs(TRILIUM_DATA_DIR: string) {
 
 }
 
-const TRILIUM_DATA_DIR = getTriliumDataDir();
+const TRILIUM_DATA_DIR = getTriliumDataDir(DIR_NAME);
 const dataDirs = getDataDirs(TRILIUM_DATA_DIR);
 
 export default dataDirs;

--- a/src/services/data_dir.ts
+++ b/src/services/data_dir.ts
@@ -32,11 +32,13 @@ function getAppDataDir() {
 }
 
 const DIR_NAME = "trilium-data";
+const FOLDER_PERMISSIONS = 0o700;
+
 
 function getTriliumDataDir() {
     if (process.env.TRILIUM_DATA_DIR) {
         if (!fs.existsSync(process.env.TRILIUM_DATA_DIR)) {
-            fs.mkdirSync(process.env.TRILIUM_DATA_DIR, 0o700);
+            fs.mkdirSync(process.env.TRILIUM_DATA_DIR, FOLDER_PERMISSIONS);
         }
 
         return process.env.TRILIUM_DATA_DIR;
@@ -51,7 +53,7 @@ function getTriliumDataDir() {
     const appDataPath = getAppDataDir() + path.sep + DIR_NAME;
 
     if (!fs.existsSync(appDataPath)) {
-        fs.mkdirSync(appDataPath, 0o700);
+        fs.mkdirSync(appDataPath, FOLDER_PERMISSIONS);
     }
 
     return appDataPath;


### PR DESCRIPTION
Hi,

this PR aims to refactor the `data_dir.ts` file.

- make code more DRY, reducing duplicate code
- switch to using path.join instead of manual path concatenation using path.sep
- reordered logic in the `getTriliumDataDir` function to be more easy to follow the order of "trilium data path order of priority"
- added tests for these functions (except for getTriliumDataDir -> see below please)
- replacing previously exported values with a proper readonly object, that is now also testable

regarding the `getTriliumDataDir` tests:
since this function is also using `fs` related methods (i.e. checking for folder existance and folder creation), I have to ways on how to make the function testable:

a) using a simple DI object, to "inject" these dependencies (`fs` methods, etc.) which will allow to mock these functions in the tests, e.g. like so:
```
export function getTriliumDataDir(di = {createDirIfNotExisting, existsSync: fs.existsSync, getPlatformAppDataDir}) {
...
di.createDirIfNotExisting(...)
...
}
```
in the tests, these would be swapped out by mocks, in the "production" code these are just using the real methods by default.

b) using the *real* methods and then having to make sure folders are cleaned up afterwards

I personally would prefer a) however I did not see this technique being used in the repo so far, so would like to have an OK before I go that route?

@eliandoran  what do you think?