### PR TITLE
chore(deps): remove unused tree-kill dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
         "stream-throttle": "0.1.3",
         "striptags": "3.2.0",
         "tmp": "0.2.3",
-        "tree-kill": "1.2.2",
         "ts-loader": "9.5.1",
         "turndown": "7.2.0",
         "unescape": "1.0.1",
@@ -17336,15 +17335,6 @@
       },
       "peerDependencies": {
         "tslib": "2"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
       }
     },
     "node_modules/trim-repeated": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "stream-throttle": "0.1.3",
     "striptags": "3.2.0",
     "tmp": "0.2.3",
-    "tree-kill": "1.2.2",
     "ts-loader": "9.5.1",
     "turndown": "7.2.0",
     "unescape": "1.0.1",

--- a/spec/support/etapi.ts
+++ b/spec/support/etapi.ts
@@ -1,5 +1,4 @@
 import child_process from "child_process";
-import kill from "tree-kill";
 
 let etapiAuthToken: string | undefined;
 


### PR DESCRIPTION
Hi,

this removes the now unused `tree-kill` dependency.

The code that used it got removed with commit e393914,
but seems that the dependency remained as leftover.