### PR TITLE
Added support for RFC 5870 geo-URIs

### DIFF
--- a/src/public/app/services/link.ts
+++ b/src/public/app/services/link.ts
@@ -276,7 +276,7 @@ function goToLinkExt(evt: MouseEvent | JQuery.ClickEvent, hrefLink: string | und
         ) {
             if (hrefLink.toLowerCase().startsWith('http') || hrefLink.startsWith("api/")) {
                 window.open(hrefLink, '_blank');
-            } else if (hrefLink.toLowerCase().startsWith('file:') && utils.isElectron()) {
+            } else if ((hrefLink.toLowerCase().startsWith('file:') || hrefLink.toLowerCase().startsWith('geo:')) && utils.isElectron()) {
                 const electron = utils.dynamicRequire('electron');
                 electron.shell.openPath(hrefLink);
             } else {
@@ -287,7 +287,7 @@ function goToLinkExt(evt: MouseEvent | JQuery.ClickEvent, hrefLink: string | und
                     'http', 'https', 'ftp', 'ftps', 'mailto', 'data', 'evernote', 'file', 'facetime', 'gemini', 'git',
                     'gopher', 'imap', 'irc', 'irc6', 'jabber', 'jar', 'lastfm', 'ldap', 'ldaps', 'magnet', 'message',
                     'mumble', 'nfs', 'onenote', 'pop', 'rmi', 's3', 'sftp', 'skype', 'sms', 'spotify', 'steam', 'svn', 'udp',
-                    'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero'
+                    'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero', 'geo'
                 ];
                 if (allowedSchemes.some(protocol => hrefLink.toLowerCase().startsWith(protocol+':'))){
                     window.open(hrefLink, '_blank');

--- a/src/services/html_sanitizer.ts
+++ b/src/services/html_sanitizer.ts
@@ -60,7 +60,7 @@ function sanitize(dirtyHtml: string) {
             'http', 'https', 'ftp', 'ftps', 'mailto', 'data', 'evernote', 'file', 'facetime', 'gemini', 'git',
             'gopher', 'imap', 'irc', 'irc6', 'jabber', 'jar', 'lastfm', 'ldap', 'ldaps', 'magnet', 'message',
             'mumble', 'nfs', 'onenote', 'pop', 'rmi', 's3', 'sftp', 'skype', 'sms', 'spotify', 'steam', 'svn', 'udp',
-            'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero'
+            'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero', 'geo'
         ],
         nonTextTags: [
             'head'


### PR DESCRIPTION
These changes add support for geo-URIs as described in [RFC 5870](https://www.rfc-editor.org/rfc/rfc5870).  
To take effect, they depend on a second pull request for [TriliumNext/trilium-ckeditor5](https://github.com/TriliumNext/trilium-ckeditor5): [here](https://github.com/TriliumNext/trilium-ckeditor5/pull/3).

Geo-URIs are mostly handled by the OS so I implemented them similar to the file-scheme. GNOME on Linux and Android both offer out-of-the-box support for geo-URIs. Others need third-party apps.  
Geo-URIs are handy for referencing locations in notes.