### PR TITLE
fix(views/set_password): various smaller fixes

### DIFF
--- a/src/views/set_password.ejs
+++ b/src/views/set_password.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <title><%= t("login.title") %></title>
+    <title><%= t("set_password.title") %></title>
     <link rel="apple-touch-icon" sizes="180x180" href="<%= assetPath %>/images/app-icons/ios/apple-touch-icon.png">
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="<%= assetPath %>/node_modules/bootstrap/dist/css/bootstrap.min.css">

--- a/src/views/set_password.ejs
+++ b/src/views/set_password.ejs
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div class="container">
-    <div class="col-xs-12 col-sm-10 col-md-6 col-lg-4 col-xl-4 mx-auto" style="padding-top: 25px;">
+    <div class="col-xs-12 col-sm-10 col-md-6 col-lg-4 col-xl-4 mx-auto pt-4">
         <h1><%= t("set_password.heading") %></h1>
 
         <% if (error) { %>

--- a/src/views/set_password.ejs
+++ b/src/views/set_password.ejs
@@ -22,15 +22,15 @@
 
         <form action="set-password" method="POST">
             <div class="form-group">
-                <label for="password"><%= t("set_password.password") %></label>
+                <label for="password1"><%= t("set_password.password") %></label>
                 <div class="controls">
-                    <input id="password" name="password1" placeholder="" class="form-control" type="password">
+                    <input id="password1" name="password1" placeholder="" class="form-control" type="password">
                 </div>
             </div>
             <div class="form-group">
-                <label for="password"><%= t("set_password.password-confirmation") %></label>
+                <label for="password2"><%= t("set_password.password-confirmation") %></label>
                 <div class="controls">
-                    <input id="password" name="password2" placeholder="" class="form-control" type="password">
+                    <input id="password2" name="password2" placeholder="" class="form-control" type="password">
                 </div>
             </div>
 

--- a/src/views/set_password.ejs
+++ b/src/views/set_password.ejs
@@ -6,6 +6,10 @@
     <title><%= t("login.title") %></title>
     <link rel="apple-touch-icon" sizes="180x180" href="<%= assetPath %>/images/app-icons/ios/apple-touch-icon.png">
     <link rel="shortcut icon" href="favicon.ico">
+    <link rel="stylesheet" href="<%= assetPath %>/node_modules/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="<%= assetPath %>/stylesheets/theme-light.css">
+    <link rel="stylesheet" href="<%= assetPath %>/stylesheets/theme-next.css">
+    <link rel="stylesheet" href="<%= assetPath %>/stylesheets/style.css">
 </head>
 <body>
 <div class="container">
@@ -45,10 +49,5 @@
     // Required for correct loading of scripts in Electron
     if (typeof module === 'object') {window.module = module; module = undefined;}
 </script>
-
-<link href="<%= assetPath %>/node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="<%= assetPath %>/stylesheets/theme-light.css" rel="stylesheet" />
-<link href="<%= assetPath %>/stylesheets/theme-next.css" rel="stylesheet" />
-<link href="<%= assetPath %>/stylesheets/style.css" rel="stylesheet">
 </body>
 </html>

--- a/translations/cn/server.json
+++ b/translations/cn/server.json
@@ -101,6 +101,7 @@
         "button": "登录"
     },
     "set_password": {
+        "title": "设置密码",
         "heading": "设置密码",
         "description": "在您可以从Web开始使用Trilium之前，您需要先设置一个密码。然后您将使用此密码登录。",
         "password": "密码",

--- a/translations/de/server.json
+++ b/translations/de/server.json
@@ -100,6 +100,7 @@
     "button": "Anmelden"
   },
   "set_password": {
+    "title": "Passwort festlegen",
     "heading": "Passwort festlegen",
     "description": "Bevor du Trilium im Web verwenden kannst, musst du zuerst ein Passwort festlegen. Du wirst dieses Passwort dann zur Anmeldung verwenden.",
     "password": "Passwort",

--- a/translations/en/server.json
+++ b/translations/en/server.json
@@ -101,6 +101,7 @@
     "button": "Login"
   },
   "set_password": {
+    "title": "Set Password",
     "heading": "Set password",
     "description": "Before you can start using Trilium from web, you need to set a password first. You will then use this password to login.",
     "password": "Password",

--- a/translations/es/server.json
+++ b/translations/es/server.json
@@ -101,6 +101,7 @@
     "button": "Iniciar sesión"
   },
   "set_password": {
+    "title": "Establecer contraseña",
     "heading": "Establecer contraseña",
     "description": "Antes de poder comenzar a usar Trilium desde la web, primero debe establecer una contraseña. Luego utilizará esta contraseña para iniciar sesión.",
     "password": "Contraseña",

--- a/translations/fr/server.json
+++ b/translations/fr/server.json
@@ -100,6 +100,7 @@
     "button": "Connexion"
   },
   "set_password": {
+    "title": "Définir un mot de passe",
     "heading": "Définir un mot de passe",
     "description": "Avant de pouvoir commencer à utiliser Trilium depuis le web, vous devez d'abord définir un mot de passe. Vous utiliserez ensuite ce mot de passe pour vous connecter.",
     "password": "Mot de passe",

--- a/translations/pt_br/server.json
+++ b/translations/pt_br/server.json
@@ -101,6 +101,7 @@
     "button": "Login"
   },
   "set_password": {
+    "title": "Definir senha",
     "heading": "Definir senha",
     "description": "Antes de começar a usar o Trilium web, você precisa definir uma senha. Você usará essa senha para fazer login.",
     "password": "Senha",

--- a/translations/ro/server.json
+++ b/translations/ro/server.json
@@ -101,6 +101,7 @@
     "title": "Autentificare"
   },
   "set_password": {
+    "title": "Setare parolă",
     "heading": "Setare parolă",
     "button": "Setează parola",
     "description": "Înainte de a putea utiliza Trilium din navigator, trebuie mai întâi setată o parolă. Ulterior această parolă va fi folosită la autentificare.",

--- a/translations/tw/server.json
+++ b/translations/tw/server.json
@@ -100,6 +100,7 @@
        "button":"登入"
     },
     "set_password":{
+       "title":"設定密碼",
        "heading":"設定密碼",
        "description":"在您可以從Web開始使用Trilium之前，您需要先設定一個密碼。然後您將使用此密碼登錄。",
        "password":"密碼",


### PR DESCRIPTION
Hi,

this PR fixes some tiny things in the `set_password` view (see commit messages).

Regarding the `set_password.title` comment I made in the one commit message:
Currently the title is just showing "Set Password", without any hint that this is a TriliumNext page (except for the favicon).
E.g. the "main" view is showing the page title as "${Note Title} - TriliumNext Notes", which makes it easy to spot.
I'll work on this on a separate PR though.