### PR TITLE
refactor(views): use ejs partial for injecting window.glob

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -34,6 +34,7 @@ function index(req: Request, res: Response) {
 
     const isElectron = utils.isElectron();
     res.render(view, {
+        device: view,
         csrfToken: csrfToken,
         themeCssUrl: getThemeCssUrl(theme, themeNote),
         themeUseNextAsBase: themeNote?.getAttributeValue("label", "appThemeBase") === "next",
@@ -51,7 +52,7 @@ function index(req: Request, res: Response) {
         instanceName: config.General ? config.General.instanceName : null,
         appCssNoteIds: getAppCssNoteIds(),
         isDev: env.isDev(),
-        isMainWindow: !req.query.extraWindow,
+        isMainWindow: (view === "mobile") ? true : !req.query.extraWindow,
         isProtectedSessionAvailable: protectedSessionService.isProtectedSessionAvailable(),
         maxContentWidth: Math.max(640, parseInt(options.maxContentWidth)),
         triliumVersion: packageJson.version,

--- a/src/views/desktop.ejs
+++ b/src/views/desktop.ejs
@@ -21,29 +21,7 @@
 
 <div class="dropdown-menu dropdown-menu-sm" id="context-menu-container"></div>
 
-<script type="text/javascript">
-    global = globalThis; /* fixes https://github.com/webpack/webpack/issues/10035 */
-
-    window.glob = {
-        device: "desktop",
-        baseApiUrl: 'api/',
-        activeDialog: null,
-        maxEntityChangeIdAtLoad: <%= maxEntityChangeIdAtLoad %>,
-        maxEntityChangeSyncIdAtLoad: <%= maxEntityChangeSyncIdAtLoad %>,
-        instanceName: '<%= instanceName %>',
-        csrfToken: '<%= csrfToken %>',
-        isDev: <%= isDev %>,
-        appCssNoteIds: <%- JSON.stringify(appCssNoteIds) %>,
-        isMainWindow: <%= isMainWindow %>,
-        isProtectedSessionAvailable: <%= isProtectedSessionAvailable %>,
-        triliumVersion: "<%= triliumVersion %>",
-        assetPath: "<%= assetPath %>",
-        appPath: "<%= appPath %>",
-        platform: "<%= platform %>",
-        hasNativeTitleBar: <%= hasNativeTitleBar %>,
-        TRILIUM_SAFE_MODE: <%= !!process.env.TRILIUM_SAFE_MODE %>
-    };
-</script>
+<%- include("./partials/windowGlobal.ejs", locals) %>
 
 <style>
     .note-split {

--- a/src/views/mobile.ejs
+++ b/src/views/mobile.ejs
@@ -106,26 +106,7 @@
 
 <div class="dropdown-menu dropdown-menu-sm" id="context-menu-container"></div>
 
-<script type="text/javascript">
-    global = globalThis; /* fixes https://github.com/webpack/webpack/issues/10035 */
-
-    window.glob = {
-        device: "mobile",
-        baseApiUrl: 'api/',
-        activeDialog: null,
-        maxEntityChangeIdAtLoad: <%= maxEntityChangeIdAtLoad %>,
-        maxEntityChangeSyncIdAtLoad: <%= maxEntityChangeSyncIdAtLoad %>,
-        instanceName: '<%= instanceName %>',
-        csrfToken: '<%= csrfToken %>',
-        isDev: <%= isDev %>,
-        appCssNoteIds: <%- JSON.stringify(appCssNoteIds) %>,
-        isMainWindow: true,
-        isProtectedSessionAvailable: <%= isProtectedSessionAvailable %>,
-        assetPath: "<%= assetPath %>",
-        appPath: "<%= appPath %>",
-        TRILIUM_SAFE_MODE: <%= !!process.env.TRILIUM_SAFE_MODE %>
-    };
-</script>
+<%- include("./partials/windowGlobal.ejs", locals) %>
 
 <script src="<%= assetPath %>/node_modules/jquery/dist/jquery.min.js"></script>
 

--- a/src/views/partials/windowGlobal.ejs
+++ b/src/views/partials/windowGlobal.ejs
@@ -1,0 +1,23 @@
+<script type="text/javascript">
+    global = globalThis; /* fixes https://github.com/webpack/webpack/issues/10035 */
+
+    window.glob = {
+        device: "<%= device %>",
+        baseApiUrl: 'api/',
+        activeDialog: null,
+        maxEntityChangeIdAtLoad: <%= maxEntityChangeIdAtLoad %>,
+        maxEntityChangeSyncIdAtLoad: <%= maxEntityChangeSyncIdAtLoad %>,
+        instanceName: '<%= instanceName %>',
+        csrfToken: '<%= csrfToken %>',
+        isDev: <%= isDev %>,
+        appCssNoteIds: <%- JSON.stringify(appCssNoteIds) %>,
+        isMainWindow: <%= isMainWindow %>,
+        isProtectedSessionAvailable: <%= isProtectedSessionAvailable %>,
+        triliumVersion: "<%= triliumVersion %>",
+        assetPath: "<%= assetPath %>",
+        appPath: "<%= appPath %>",
+        platform: "<%= platform %>",
+        hasNativeTitleBar: <%= hasNativeTitleBar %>,
+        TRILIUM_SAFE_MODE: <%= !!process.env.TRILIUM_SAFE_MODE %>
+    };
+</script>


### PR DESCRIPTION
Hi,

this PR aims to reduce code duplication, by using an ejs partial for injecting the window.glob part.

Now we only have to take care of it in one single place :-)