### PR TITLE
chore(prettier): add prettier as devDep and scripts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+*.html
+*.md
+*.yml
+libraries/*
+docs/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,7 @@
         "jsdoc": "4.0.4",
         "lorem-ipsum": "2.0.8",
         "nodemon": "3.1.9",
+        "prettier": "3.4.2",
         "rcedit": "4.0.1",
         "rimraf": "6.0.1",
         "ts-node": "10.9.2",
@@ -14694,6 +14695,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/print-this": {

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "jsdoc": "4.0.4",
     "lorem-ipsum": "2.0.8",
     "nodemon": "3.1.9",
+    "prettier": "3.4.2",
     "rcedit": "4.0.1",
     "rimraf": "6.0.1",
     "ts-node": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "integration-mem-db": "cross-env TRILIUM_INTEGRATION_TEST=memory TRILIUM_PORT=8082 TRILIUM_DATA_DIR=./integration-tests/db nodemon src/main.ts",
     "integration-mem-db-dev": "cross-env TRILIUM_INTEGRATION_TEST=memory TRILIUM_PORT=8082 TRILIUM_ENV=dev TRILIUM_DATA_DIR=./integration-tests/db nodemon src/main.ts",
     "generate-document": "cross-env nodemon src/tools/generate_document.ts 1000",
-    "ci-update-nightly-version": "tsx ./bin/update-nightly-version.ts"
+    "ci-update-nightly-version": "tsx ./bin/update-nightly-version.ts",
+    "prettier-check": "prettier . --check",
+    "prettier-fix": "prettier . --write"
   },
   "dependencies": {
     "@braintree/sanitize-url": "7.1.1",


### PR DESCRIPTION
Hi,

I found a `.prettierrc` file in the root of the folder, which got added via https://github.com/TriliumNext/Notes/pull/165
However I did not find it in the devDependencies.

I've added it as devDep and added two basic scripts to run prettier and I added an initial `.prettierignore` – this one might need some tweaking still.

The prettier check shows more than 600 files that would need "editing" – but that is not part of this PR.