### PR TITLE
chore(prettier): add override for *.json tab width to match .editorconfig

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,5 +10,13 @@
     "arrowParens": "always",
     "proseWrap": "preserve",
     "htmlWhitespaceSensitivity": "css",
-    "endOfLine": "lf"
+    "endOfLine": "lf",
+    "overrides": [
+        {
+            "files": ["*.json"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Hi,

I've added an override section for json files, to match the tab width to the "indent_size" value from the `.editorconfig`.