### PR TITLE
fix(styles): fix ck-editor checkboxes not showing checkmark while printing

### DIFF
--- a/src/public/stylesheets/print.css
+++ b/src/public/stylesheets/print.css
@@ -25,4 +25,11 @@
         border: 0.75pt solid gray !important;
         border-radius: 2pt !important;
     }
+
+    /* Fix visibility of checkbox checkmarks
+       see https://github.com/TriliumNext/Notes/issues/901 */
+    .ck-editor__editable.ck-content .todo-list .todo-list__label > span[contenteditable="false"] > input[checked]::after {
+        /* fallback to default ck-editor green */
+        border-color: hsl(126, 64%, 41%);
+    }
 }


### PR DESCRIPTION
Hi,

this PR aims to fix #901. As per comment https://github.com/TriliumNext/Notes/issues/901#issuecomment-2579632456 I  did not add all of the styles, but instead had to add a "workaround" for `print.css`.

The main issue here is that browsers will strip all background colors when printing, and the input checkboxes coming from ck-editor unfortunately all use custom styling, which involves setting the background (e.g. to green) and the color of the checkmark to white.
After the browser strips the background color, the checkmark is still there, but it is "white on white", which makes it invisible.

A bit "hack-ish" solution, which works well enough though:
we set the input's border to half the size of the input element to create a fake background, that the browser will not strip out, when you enter print mode.
Due to CSS specificity using plain "input[checked]::before" does not work.

The hsl color code comes from `ckeditor-content.css`

In the end it looks like this:

![grafik](https://github.com/user-attachments/assets/ba0e3e12-8551-4111-9436-af66501354df)


fixes #901