### PR TITLE
refactor(backend_log): improve `getBackendLog`

### DIFF
--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -1,14 +1,14 @@
 "use strict";
 
 import { readFile  } from "fs/promises";
+import { join } from "path";
 import dateUtils from "../../services/date_utils.js";
 import dataDir from "../../services/data_dir.js";
 const { LOG_DIR } = dataDir;
 
 async function getBackendLog() {
-    const file = `${LOG_DIR}/trilium-${dateUtils.localNowDate()}.log`;
-
     try {
+        const file = join(LOG_DIR, `trilium-${dateUtils.localNowDate()}.log`);
         return await readFile(file, "utf8");
     } catch (e) {
         // most probably the log file does not exist yet - https://github.com/zadam/trilium/issues/1977

--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -9,11 +9,12 @@ import log from "../../services/log.js";
 const { LOG_DIR } = dataDir;
 
 async function getBackendLog() {
+    const fileName = `trilium-${dateUtils.localNowDate()}.log`
     try {
-        const file = join(LOG_DIR, `trilium-${dateUtils.localNowDate()}.log`);
+        const file = join(LOG_DIR, fileName);
         return await readFile(file, "utf8");
     } catch (e) {
-        log.error((e instanceof Error) ? e : "Reading the Backend Log failed with an unknown error.");
+        log.error((e instanceof Error) ? e : `Reading the backend log '${fileName}' failed with an unknown error.`);
 
         // most probably the log file does not exist yet - https://github.com/zadam/trilium/issues/1977
         return "";

--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -14,10 +14,16 @@ async function getBackendLog() {
         const file = join(LOG_DIR, fileName);
         return await readFile(file, "utf8");
     } catch (e) {
-        log.error((e instanceof Error) ? e : `Reading the backend log '${fileName}' failed with an unknown error.`);
+        const isErrorInstance = e instanceof Error;
 
         // most probably the log file does not exist yet - https://github.com/zadam/trilium/issues/1977
-        return "";
+        if (isErrorInstance && "code" in e && e.code === "ENOENT") {
+            log.error(e);
+            return `The backend log file '${fileName}' does not exist (yet).`;
+        }
+
+        log.error(isErrorInstance ? e : `Reading the backend log '${fileName}' failed with an unknown error: '${e}'.`);
+        return `Reading the backend log '${fileName}' failed.`;
     }
 }
 

--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { readFile  } from "fs/promises";
+import { readFile } from "fs/promises";
 import { join } from "path";
 import dateUtils from "../../services/date_utils.js";
 import dataDir from "../../services/data_dir.js";
@@ -10,7 +10,7 @@ import { t } from "i18next";
 const { LOG_DIR } = dataDir;
 
 async function getBackendLog() {
-    const fileName = `trilium-${dateUtils.localNowDate()}.log`
+    const fileName = `trilium-${dateUtils.localNowDate()}.log`;
     try {
         const file = join(LOG_DIR, fileName);
         return await readFile(file, "utf8");

--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -4,6 +4,8 @@ import { readFile  } from "fs/promises";
 import { join } from "path";
 import dateUtils from "../../services/date_utils.js";
 import dataDir from "../../services/data_dir.js";
+import log from "../../services/log.js";
+
 const { LOG_DIR } = dataDir;
 
 async function getBackendLog() {
@@ -11,6 +13,8 @@ async function getBackendLog() {
         const file = join(LOG_DIR, `trilium-${dateUtils.localNowDate()}.log`);
         return await readFile(file, "utf8");
     } catch (e) {
+        log.error((e instanceof Error) ? e : "Reading the Backend Log failed with an unknown error.");
+
         // most probably the log file does not exist yet - https://github.com/zadam/trilium/issues/1977
         return "";
     }

--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import dateUtils from "../../services/date_utils.js";
 import dataDir from "../../services/data_dir.js";
 import log from "../../services/log.js";
+import { t } from "i18next";
 
 const { LOG_DIR } = dataDir;
 
@@ -19,11 +20,11 @@ async function getBackendLog() {
         // most probably the log file does not exist yet - https://github.com/zadam/trilium/issues/1977
         if (isErrorInstance && "code" in e && e.code === "ENOENT") {
             log.error(e);
-            return `The backend log file '${fileName}' does not exist (yet).`;
+            return t("backend_log.log-does-not-exist", { fileName });
         }
 
         log.error(isErrorInstance ? e : `Reading the backend log '${fileName}' failed with an unknown error: '${e}'.`);
-        return `Reading the backend log '${fileName}' failed.`;
+        return t("backend_log.reading-log-failed", { fileName });
     }
 }
 

--- a/src/routes/api/backend_log.ts
+++ b/src/routes/api/backend_log.ts
@@ -1,15 +1,15 @@
 "use strict";
 
-import fs from "fs";
+import { readFile  } from "fs/promises";
 import dateUtils from "../../services/date_utils.js";
 import dataDir from "../../services/data_dir.js";
 const { LOG_DIR } = dataDir;
 
-function getBackendLog() {
+async function getBackendLog() {
     const file = `${LOG_DIR}/trilium-${dateUtils.localNowDate()}.log`;
 
     try {
-        return fs.readFileSync(file, "utf8");
+        return await readFile(file, "utf8");
     } catch (e) {
         // most probably the log file does not exist yet - https://github.com/zadam/trilium/issues/1977
         return "";

--- a/translations/de/server.json
+++ b/translations/de/server.json
@@ -193,5 +193,9 @@
   "test_sync": {
     "not-configured": "Der Synchronisations-Server-Host ist nicht konfiguriert. Bitte konfiguriere zuerst die Synchronisation.",
     "successful": "Die Server-Verbindung wurde erfolgreich hergestellt, die Synchronisation wurde gestartet."
+  },
+  "backend_log": {
+    "log-does-not-exist": "Die Backend-Log-Datei '{{ fileName }}' existiert (noch) nicht.",
+    "reading-log-failed": "Das Lesen der Backend-Log-Datei '{{ fileName }}' ist fehlgeschlagen."
   }
 }

--- a/translations/en/server.json
+++ b/translations/en/server.json
@@ -246,5 +246,9 @@
     "new-note": "New note",
     "duplicate-note-suffix": "(dup)",
     "duplicate-note-title": "{{ noteTitle }} {{ duplicateNoteSuffix }}"
+  },
+  "backend_log": {
+    "log-does-not-exist": "The backend log file '{{ fileName }}' does not exist (yet).",
+    "reading-log-failed": "Reading the backend log file '{{ fileName }}' failed."
   }
 }


### PR DESCRIPTION
Hi

this PR aims to improve the `getBackendLog` function in the `backend_log` route:

most notable:
- I've replaced the synchronous reading of the file with an async reading, which makes more sense for a backend api function
- error handling is more user friendly, as they get back an actual message instead of just an empty string