### PR TITLE
fix(views): replace deprecated meta tag

### DIFF
--- a/src/views/desktop.ejs
+++ b/src/views/desktop.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <link rel="shortcut icon" href="favicon.ico">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <link rel="manifest" crossorigin="use-credentials" href="manifest.webmanifest">

--- a/src/views/mobile.ejs
+++ b/src/views/mobile.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <link rel="shortcut icon" href="favicon.ico">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#fff">


### PR DESCRIPTION
Hi,

Chrome was throwing a warning at me recently
![Screenshot_20250113_204541](https://github.com/user-attachments/assets/ace8748e-b539-4ccb-8d86-b3b063567fc9)

This PR fixes that, it also was already implemented by e.g. Flutter or vercel/Next.js, so we should be OK here ;-)

https://github.com/vercel/next.js/pull/70363
https://github.com/flutter/flutter/issues/154596