### PR TITLE
Add server logging for CKEditor state changes

### DIFF
--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -170,7 +170,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
                 return;
             }
 
-            console.log(`CKEditor changed to ${currentState}`);
+            logInfo(`CKEditor changed to ${currentState}`)
 
             this.watchdog.crashes.forEach((crashInfo) => console.log(crashInfo));
 
@@ -182,6 +182,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         });
 
         this.watchdog.setCreator(async (elementOrData, editorConfig) => {
+            logInfo("Creating new CKEditor")
             const extraOpts = {};
             if (isClassicEditor) {
                 extraOpts.toolbar = {

--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -165,13 +165,13 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
 
         this.watchdog.on("stateChange", () => {
             const currentState = this.watchdog.state;
+            logInfo(`CKEditor state changed to ${currentState}`);
 
             if (!["crashed", "crashedPermanently"].includes(currentState)) {
                 return;
             }
 
-            logInfo(`CKEditor changed to ${currentState}`)
-
+            logInfo(`CKEditor crash logs: ${JSON.stringify(this.watchdog.crashes)}`);
             this.watchdog.crashes.forEach((crashInfo) => console.log(crashInfo));
 
             if (currentState === "crashedPermanently") {
@@ -182,7 +182,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         });
 
         this.watchdog.setCreator(async (elementOrData, editorConfig) => {
-            logInfo("Creating new CKEditor")
+            logInfo("Creating new CKEditor");
             const extraOpts = {};
             if (isClassicEditor) {
                 extraOpts.toolbar = {


### PR DESCRIPTION
For #454 and #831, it would be useful to have logging about the state of the CKEditor in the server logs. This could help give us better understanding of frontend crashes, and other weird frontend state.