### PR TITLE
Fix default ivLength in dump-db tool

### DIFF
--- a/dump-db/inc/data_key.ts
+++ b/dump-db/inc/data_key.ts
@@ -12,7 +12,7 @@ function getDataKey(password: any) {
 
         const encryptedDataKey = getOption("encryptedDataKey");
 
-        const decryptedDataKey = decryptService.decrypt(passwordDerivedKey, encryptedDataKey, 16);
+        const decryptedDataKey = decryptService.decrypt(passwordDerivedKey, encryptedDataKey);
 
         return decryptedDataKey;
     } catch (e: any) {

--- a/dump-db/inc/decrypt.ts
+++ b/dump-db/inc/decrypt.ts
@@ -16,7 +16,7 @@ function decryptString(dataKey: any, cipherText: any) {
     return str;
 }
 
-function decrypt(key: any, cipherText: any, ivLength = 13) {
+function decrypt(key: any, cipherText: any, ivLength = 16) {
     if (cipherText === null) {
         return null;
     }

--- a/dump-db/inc/decrypt.ts
+++ b/dump-db/inc/decrypt.ts
@@ -16,7 +16,7 @@ function decryptString(dataKey: any, cipherText: any) {
     return str;
 }
 
-function decrypt(key: any, cipherText: any, ivLength = 16) {
+function decrypt(key: any, cipherText: any) {
     if (cipherText === null) {
         return null;
     }
@@ -27,6 +27,8 @@ function decrypt(key: any, cipherText: any, ivLength = 16) {
 
     try {
         const cipherTextBufferWithIv = Buffer.from(cipherText.toString(), "base64");
+        // old encrypted data can have IV of length 13, see some details here: https://github.com/zadam/trilium/issues/3017
+        const ivLength = cipherTextBufferWithIv.length % 16 === 0 ? 16 : 13;
         const iv = cipherTextBufferWithIv.slice(0, ivLength);
 
         const cipherTextBuffer = cipherTextBufferWithIv.slice(ivLength);


### PR DESCRIPTION
The `dump-db` tool appears to be designed for a much older version of Trilium.

Related issue:
https://github.com/zadam/trilium/issues/3017
Referencing this commit:  
[Commit Reference](https://github.com/zadam/trilium/commit/5a37547b37177d81e12532ba02c40e53562c614e)

At that time, the `ivLength` was incorrectly set to 13 instead of the correct value of 16. Consequently, if you attempt to use this tool to decrypt encrypted notes from the current database version, you will encounter errors because the tool's default `ivLength` remains at 13.

Code reference:  
[Source Code Reference](https://github.com/TriliumNext/Notes/blob/7dfeb20678708ecb3d12852c6bac857af1bfd59b/dump-db/inc/decrypt.ts#L19)

Error message:  
`Caught WRONG_FINAL_BLOCK_LENGTH, returning cipherText instead`

To reproduce the issue, you can use the following test code:
```bash
npx esrun dump-db.ts --password 1234 document.db output/
```

To resolve this issue and ensure compatibility with the current database, the `ivLength` should be updated to a default value of 16.