### PR TITLE
fix(csrf): fix handling of existing _csrf cookies

### DIFF
--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -1,0 +1,15 @@
+import { doubleCsrf } from "csrf-csrf";
+import sessionSecret from "../services/session_secret.js";
+
+const doubleCsrfUtilities = doubleCsrf({
+    getSecret: () => sessionSecret,
+    cookieOptions: {
+        path: "", // empty, so cookie is valid only for the current path
+        secure: false,
+        sameSite: false,
+        httpOnly: false
+    },
+    cookieName: "_csrf"
+});
+
+export const { doubleCsrfProtection } = doubleCsrfUtilities;

--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -12,4 +12,4 @@ const doubleCsrfUtilities = doubleCsrf({
     cookieName: "_csrf"
 });
 
-export const { doubleCsrfProtection } = doubleCsrfUtilities;
+export const { generateToken, doubleCsrfProtection } = doubleCsrfUtilities;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -11,6 +11,8 @@ import protectedSessionService from "../services/protected_session.js";
 import packageJson from "../../package.json" with { type: "json" };
 import assetPath from "../services/asset_path.js";
 import appPath from "../services/app_path.js";
+import { generateToken as generateCsrfToken } from "./csrf_protection.js";
+
 import type { Request, Response } from "express";
 import type BNote from "../becca/entities/bnote.js";
 
@@ -19,7 +21,9 @@ function index(req: Request, res: Response) {
 
     const view = !utils.isElectron() && req.cookies["trilium-device"] === "mobile" ? "mobile" : "desktop";
 
-    const csrfToken = (typeof req.csrfToken === "function") ? req.csrfToken() : undefined;
+    //'overwrite' set to false (default) => the existing token will be re-used and validated
+    //'validateOnReuse' set to false => if validation fails, generate a new token instead of throwing an error
+    const csrfToken = generateCsrfToken(req, res, false, false);
     log.info(`Generated CSRF token ${csrfToken} with secret ${res.getHeader("set-cookie")}`);
 
     // We force the page to not be cached since on mobile the CSRF token can be

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -9,13 +9,12 @@ import auth from "../services/auth.js";
 import cls from "../services/cls.js";
 import sql from "../services/sql.js";
 import entityChangesService from "../services/entity_changes.js";
-import { doubleCsrf } from "csrf-csrf";
+import { doubleCsrfProtection as csrfMiddleware } from "./csrf_protection.js";
 import { createPartialContentHandler } from "@triliumnext/express-partial-content";
 import rateLimit from "express-rate-limit";
 import AbstractBeccaEntity from "../becca/entities/abstract_becca_entity.js";
 import NotFoundError from "../errors/not_found_error.js";
 import ValidationError from "../errors/validation_error.js";
-import sessionSecret from "../services/session_secret.js";
 
 // page routes
 import setupRoute from "./setup.js";
@@ -72,16 +71,7 @@ import etapiSpecialNoteRoutes from "../etapi/special_notes.js";
 import etapiSpecRoute from "../etapi/spec.js";
 import etapiBackupRoute from "../etapi/backup.js";
 
-const { doubleCsrfProtection: csrfMiddleware } = doubleCsrf({
-    getSecret: () => sessionSecret,
-    cookieOptions: {
-        path: "", // empty, so cookie is valid only for the current path
-        secure: false,
-        sameSite: false,
-        httpOnly: false
-    },
-    cookieName: "_csrf"
-});
+
 
 const MAX_ALLOWED_FILE_SIZE_MB = 250;
 const GET = "get",


### PR DESCRIPTION
Hi,

this PR changes the way the `_csrf` cookie is being handled during generation.

I've switched over from using the `req.csrf` method (which get's added *after* the request passes the csrfMiddleWare) to explicitly using `doubleCsrf`'s `generateToken` method.
This allows us to change the parameters (a bit more easily and without any typing issues) as per below:
 //'overwrite' set to false (default) => the existing token will be re-used and validated
 //'validateOnReuse' set to false => if validation fails, generate a new token instead of throwing an error

See https://www.npmjs.com/package/csrf-csrf under "generateToken" for further info.

While I as at it, I've refactored the csrf_protection to its own file, for better separation, similar to what was done with the session_parser middleware.

the change also fixes #950 