### PR TITLE
fix(csrf): set more secure csrf related settings

### DIFF
--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -6,8 +6,8 @@ const doubleCsrfUtilities = doubleCsrf({
     cookieOptions: {
         path: "", // empty, so cookie is valid only for the current path
         secure: false,
-        sameSite: false,
-        httpOnly: false
+        sameSite: "strict",
+        httpOnly: true
     },
     cookieName: "_csrf"
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -24,7 +24,7 @@ function index(req: Request, res: Response) {
     //'overwrite' set to false (default) => the existing token will be re-used and validated
     //'validateOnReuse' set to false => if validation fails, generate a new token instead of throwing an error
     const csrfToken = generateCsrfToken(req, res, false, false);
-    log.info(`Generated CSRF token ${csrfToken} with secret ${res.getHeader("set-cookie")}`);
+    log.info(`CSRF token generation: ${csrfToken ? "Successful" : "Failed"}`);
 
     // We force the page to not be cached since on mobile the CSRF token can be
     // broken when closing the browser and coming back in to the page.


### PR DESCRIPTION
Hi,

this PR sets some more "secure" settings for csrf.

##### CSRF token shouldn't be leaked in server logs (according to OWASP)
As per OWASP:
"A CSRF token must not be leaked in the server logs or in the URL.", see:
https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#transmissing-csrf-tokens-in-synchronized-patterns

##### set httpOnly and sameSite for the `_csrf` cookie

- `sameSite` - previous setting inherited from csurf was to simply not set it at all (i.e. "none"), which makes all browser nag in their dev console output.
They will default to "Lax" for these type of cookies in the future.
We can even use "strict" here though for our use case without an issue:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value

- `httpOnly`: should be enabled for the csrf cookie as well
for the session cookie it already is enabled.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly