### PR TITLE
Fix parent share link

### DIFF
--- a/src/views/share/page.ejs
+++ b/src/views/share/page.ejs
@@ -37,7 +37,7 @@
     <div id="main">
         <% if (note.parents[0].noteId !== '_share' && note.parents.length !== 0) { %>
             <nav id="parentLink">
-                <%= t("share_page.parent") %> <a href="<%= note.parents[0].shareId %>"
+                <%= t("share_page.parent") %> <a href="./<%= note.parents[0].shareId %>"
                                      class="type-<%= note.parents[0].type %>"><%= note.parents[0].title %></a>
             </nav>
         <% } %>


### PR DESCRIPTION
navigating from a sub note to the parent note when the parent note is the root note is broken due to the missing relative path specifier

href for the parent node if it is the root node is "" instead of "./" see the differing behavior of referencing child nodes
https://github.com/TriliumNext/Notes/blob/b2e1a3e97ad93ba5a0d48fab5444bb42275dce5a/src/views/share/page.ejs#L66-L69
vs the parent node
https://github.com/TriliumNext/Notes/blob/b2e1a3e97ad93ba5a0d48fab5444bb42275dce5a/src/views/share/page.ejs#L38-L40