### PR TITLE
fix(csrf): add exception for electron for httpOnly cookie

### DIFF
--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -1,5 +1,6 @@
 import { doubleCsrf } from "csrf-csrf";
 import sessionSecret from "../services/session_secret.js";
+import { isElectron } from "../services/utils.js";
 
 const doubleCsrfUtilities = doubleCsrf({
     getSecret: () => sessionSecret,
@@ -7,7 +8,7 @@ const doubleCsrfUtilities = doubleCsrf({
         path: "", // empty, so cookie is valid only for the current path
         secure: false,
         sameSite: "strict",
-        httpOnly: true
+        httpOnly: !isElectron() // set to false for Electron, see https://github.com/TriliumNext/Notes/pull/966
     },
     cookieName: "_csrf"
 });


### PR DESCRIPTION
Hi,

this PR is "hotfix" for an issue with Electron, that I introduced with https://github.com/TriliumNext/Notes/pull/961
I forgot to rebuild and test the electron version, sorry about that!

Electron it does not seem to like having httpOnly set, which causes the cookie *not* to be sent to the server, and hence csrf failing.

For the web/server version httpOnly is definitely working, tested on localhost and also on a deployed server with proper domain and SSL termination by nginx – httpOnly works without issues there.

Let's add an exception for isElectron for now, and check, if there is a way around it Electron as well :-)