### PR TITLE
test(spec/search): fix expect error message printing

### DIFF
--- a/spec/search/search.spec.ts
+++ b/spec/search/search.spec.ts
@@ -184,7 +184,7 @@ describe("Search", () => {
 
         function test(query: string, expectedResultCount: number) {
             const searchResults = searchService.findResultsWithQuery(query, searchContext);
-            expect(searchResults.length, `While searching for ${query} got unexpected result: [${searchResults.join(", ")}]`)
+            expect(searchResults.length, `Searching for '${query}' unexpectedly returned ${Number(searchResults?.length)} instead of ${expectedResultCount} results. SearchResult: '${JSON.stringify(searchResults)}'`)
                 .toEqual(expectedResultCount);
 
             if (expectedResultCount === 1) {


### PR DESCRIPTION
Hi,

I've adjusted message to be printed correctly and adjusted wording to make it more clear, what is actually tested here (the length of results)
 -> previously it was printing "[object object]", since we are dealing with an  array of objects