### PR TITLE
fix(utils/dynamicRequire): get rid of Webpack Critical dependency warning

### DIFF
--- a/src/public/app/services/utils.ts
+++ b/src/public/app/services/utils.ts
@@ -308,7 +308,9 @@ function dynamicRequire(moduleName: string) {
     if (typeof __non_webpack_require__ !== "undefined") {
         return __non_webpack_require__(moduleName);
     } else {
-        return require(moduleName);
+        // explicitly pass as string and not as expression to suppress webpack warning
+        // 'Critical dependency: the request of a dependency is an expression'
+        return require(`${moduleName}`);
     }
 }
 


### PR DESCRIPTION
Hi,

this PR aims to get rid of the Webpack warning that appears when running webpack:

```
WARNING in ./src/public/app/services/utils.ts 249:15-34
  Critical dependency: the request of a dependency is an expression
```

It does it by simply explicitly passing the moduleName as string using template literal and not the moduleName "expression",

Source: https://stackoverflow.com/questions/42908116/