### PR TITLE
test(data_dir): fix flaky getPlatformAppDataDir test on Windows

### DIFF
--- a/src/services/data_dir.spec.ts
+++ b/src/services/data_dir.spec.ts
@@ -77,6 +77,11 @@ describe("data_dir.ts unit tests", async () => {
             ["w/ darwin it should return '~/Library/Application Support'", ["darwin", undefined], "/Users/mock/Library/Application Support", "/Users/mock"]
         ];
 
+        beforeEach(() => {
+            // make sure OS does not set its own process.env.APPDATA, so that we can use our own supplied value
+            delete process.env.APPDATA;
+        });
+
         testCases.forEach((testCase) => {
             const [testDescription, fnValues, expected, osHomedirMockValue] = testCase;
             return it(testDescription, () => {


### PR DESCRIPTION
Hi,

this PR fixes the one flaky test on Windows for the getPlatformAppDataDir test suite.