### PR TITLE
chore: move generate_documents  to bin folder

### DIFF
--- a/bin/generate_document.ts
+++ b/bin/generate_document.ts
@@ -1,5 +1,5 @@
 /**
- * Usage: node src/tools/generate_document.js 1000
+ * Usage: tsx ./generate_document.ts 1000
  * will create 1000 new notes and some clones into the current document.db
  */
 
@@ -90,4 +90,6 @@ async function start() {
     process.exit(0);
 }
 
-sqlInit.dbReady.then(cls.wrap(start));
+// @TriliumNextTODO sqlInit.dbReady never seems to resolve so program hangs
+// see https://github.com/TriliumNext/Notes/issues/1020
+sqlInit.dbReady.then(cls.wrap(start)).catch((err) => console.error(err));

--- a/bin/generate_document.ts
+++ b/bin/generate_document.ts
@@ -3,13 +3,13 @@
  * will create 1000 new notes and some clones into the current document.db
  */
 
-import sqlInit from "../services/sql_init.js";
-import noteService from "../services/notes.js";
-import attributeService from "../services/attributes.js";
-import cls from "../services/cls.js";
-import cloningService from "../services/cloning.js";
+import sqlInit from "../src/services/sql_init.js";
+import noteService from "../src/services/notes.js";
+import attributeService from "../src/services/attributes.js";
+import cls from "../src/services/cls.js";
+import cloningService from "../src/services/cloning.js";
 import loremIpsum from "lorem-ipsum";
-import "../becca/entity_constructor.js";
+import "../src/becca/entity_constructor.js";
 
 const noteCount = parseInt(process.argv[2]);
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "integration-edit-db": "cross-env TRILIUM_INTEGRATION_TEST=edit TRILIUM_PORT=8081 TRILIUM_ENV=dev TRILIUM_DATA_DIR=./integration-tests/db nodemon src/main.ts",
     "integration-mem-db": "cross-env TRILIUM_INTEGRATION_TEST=memory TRILIUM_PORT=8082 TRILIUM_DATA_DIR=./integration-tests/db nodemon src/main.ts",
     "integration-mem-db-dev": "cross-env TRILIUM_INTEGRATION_TEST=memory TRILIUM_PORT=8082 TRILIUM_ENV=dev TRILIUM_DATA_DIR=./integration-tests/db nodemon src/main.ts",
-    "generate-document": "cross-env nodemon src/tools/generate_document.ts 1000",
+    "generate-document": "cross-env nodemon ./bin/generate_document.ts 1000",
     "ci-update-nightly-version": "tsx ./bin/update-nightly-version.ts",
     "prettier-check": "prettier . --check",
     "prettier-fix": "prettier . --write"


### PR DESCRIPTION
Hi,

this file is never called in production code and wouldn't even run, even if it was:
the `lorem-ipsum` dependency is in the `devDependencies`, so never gets installed in
any dist builds.

I moved the file to "bin" where it makes more sense, where other "like minded" scripts are found.
This way we avoid it getting packaged without any reason.

Apart from that: I've added a comment to the script -> it seems to be broken at the moment – I did not get it to run correctly. see #1020 