### PR TITLE
feat(services/config): Add ability to set Trilium configuration variables via ENV variables

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -27,3 +27,8 @@ keyPath=
 # once set, expressjs will use the X-Forwarded-For header set by the rev. proxy to determinate the real IPs of clients.
 # expressjs shortcuts are supported: loopback(127.0.0.1/8, ::1/128), linklocal(169.254.0.0/16, fe80::/10), uniquelocal(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7)
 trustedReverseProxy=false
+
+[Sync]
+#syncServerHost=
+#syncServerTimeout=
+#syncProxy=

--- a/docker_healthcheck.ts
+++ b/docker_healthcheck.ts
@@ -2,7 +2,7 @@ import http from "http";
 import ini from "ini";
 import fs from "fs";
 import dataDir from "./src/services/data_dir.js";
-const config = ini.parse(fs.readFileSync(dataDir.CONFIG_INI_PATH, "utf-8"));
+import config from "./src/services/config.js";
 
 if (config.Network.https) {
     // built-in TLS (terminated by trilium) is not supported yet, PRs are welcome

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -22,16 +22,20 @@ const config = {
     General: {
         instanceName: process.env.TRILIUM_GENERAL_INSTANCENAME || iniConfig.General.instanceName,
         noAuthentication: envToBoolean(process.env.TRILIUM_GENERAL_NOAUTHENTICATION) || iniConfig.General.noAuthentication,
-        noBackup: envToBoolean(process.env.TRILIUM_GENERAL_NOBACKUP) || iniConfig.General.noBackup
+        noBackup: envToBoolean(process.env.TRILIUM_GENERAL_NOBACKUP) || iniConfig.General.noBackup,
+        noDesktopIcon: envToBoolean(process.env.TRILIUM_GENERAL_NODESKTOPICON) || iniConfig.General.noDesktopIcon
     },
 
     Network: {
+        host: process.env.TRILIUM_NETWORK_HOST || iniConfig.Network.host,
         port: process.env.TRILIUM_NETWORK_PORT || iniConfig.Network.port,
         https: envToBoolean(process.env.TRILIUM_NETWORK_HTTPS) || iniConfig.Network.https,
         certPath: process.env.TRILIUM_NETWORK_CERTPATH  || iniConfig.Network.certPath,
         keyPath: process.env.TRILIUM_NETWORK_KEYPATH  || iniConfig.Network.keyPath,
         trustedReverseProxy: process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy
-    }
+    },
+    // @TODO correctly define here
+    //Sync: {}
 
 };
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -38,27 +38,57 @@ export interface TriliumConfig {
         syncProxy: string;
     };
 }
+
+//prettier-ignore
 const config: TriliumConfig = {
 
     General: {
-        instanceName: process.env.TRILIUM_GENERAL_INSTANCENAME || iniConfig.General.instanceName,
-        noAuthentication: envToBoolean(process.env.TRILIUM_GENERAL_NOAUTHENTICATION) || iniConfig.General.noAuthentication,
-        noBackup: envToBoolean(process.env.TRILIUM_GENERAL_NOBACKUP) || iniConfig.General.noBackup,
-        noDesktopIcon: envToBoolean(process.env.TRILIUM_GENERAL_NODESKTOPICON) || iniConfig.General.noDesktopIcon
+        instanceName:
+            process.env.TRILIUM_GENERAL_INSTANCENAME || iniConfig.General.instanceName || "",
+
+        noAuthentication: 
+            envToBoolean(process.env.TRILIUM_GENERAL_NOAUTHENTICATION) || iniConfig.General.noAuthentication || false,
+
+        noBackup: 
+            envToBoolean(process.env.TRILIUM_GENERAL_NOBACKUP) || iniConfig.General.noBackup || false,
+
+        noDesktopIcon: 
+            envToBoolean(process.env.TRILIUM_GENERAL_NODESKTOPICON) || iniConfig.General.noDesktopIcon || false
     },
 
     Network: {
-        host: process.env.TRILIUM_NETWORK_HOST || iniConfig.Network.host,
-        port: process.env.TRILIUM_NETWORK_PORT || iniConfig.Network.port,
-        https: envToBoolean(process.env.TRILIUM_NETWORK_HTTPS) || iniConfig.Network.https,
-        certPath: process.env.TRILIUM_NETWORK_CERTPATH  || iniConfig.Network.certPath,
-        keyPath: process.env.TRILIUM_NETWORK_KEYPATH  || iniConfig.Network.keyPath,
-        trustedReverseProxy: process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy
+        host:
+            process.env.TRILIUM_NETWORK_HOST || iniConfig.Network.host || "0.0.0.0",
+
+        port:
+            process.env.TRILIUM_NETWORK_PORT || iniConfig.Network.port || "3000",
+
+        https: 
+            envToBoolean(process.env.TRILIUM_NETWORK_HTTPS) || iniConfig.Network.https || false,
+
+        certPath: 
+            process.env.TRILIUM_NETWORK_CERTPATH || iniConfig.Network.certPath || "",
+
+        keyPath: 
+            process.env.TRILIUM_NETWORK_KEYPATH  || iniConfig.Network.keyPath || "",
+
+        trustedReverseProxy:
+            process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy || false
     },
-    // @TODO correctly define here
-    //Sync: {}
+
+    Sync: {
+        syncServerHost:
+            process.env.TRILIUM_SYNC_SERVER_HOST || iniConfig?.Sync?.syncServerHost || "",
+
+        syncServerTimeout:
+            process.env.TRILIUM_SYNC_SERVER_TIMEOUT || iniConfig?.Sync?.syncServerTimeout || "120000",
+
+        // @TriliumNextTODO: check if we can rename misnamed syncProxy to syncServerProxy without
+        // breaking backwards compatibility - for naming consistency
+        syncProxy:
+            process.env.TRILIUM_SYNC_SERVER_PROXY || iniConfig?.Sync?.syncProxy || ""
+    }
 
 };
-
 
 export default config;

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import dataDir from "./data_dir.js";
 import path from "path";
 import resourceDir from "./resource_dir.js";
+import { envToBoolean } from "./utils.js";
 
 const configSampleFilePath = path.resolve(resourceDir.RESOURCE_DIR, "config-sample.ini");
 
@@ -14,6 +15,25 @@ if (!fs.existsSync(dataDir.CONFIG_INI_PATH)) {
     fs.writeFileSync(dataDir.CONFIG_INI_PATH, configSample);
 }
 
-const config = ini.parse(fs.readFileSync(dataDir.CONFIG_INI_PATH, "utf-8"));
+const iniConfig = ini.parse(fs.readFileSync(dataDir.CONFIG_INI_PATH, "utf-8"));
+
+const config = {
+
+    General: {
+        instanceName: process.env.TRILIUM_GENERAL_INSTANCENAME || iniConfig.General.instanceName,
+        noAuthentication: envToBoolean(process.env.TRILIUM_GENERAL_NOAUTHENTICATION) || iniConfig.General.noAuthentication,
+        noBackup: envToBoolean(process.env.TRILIUM_GENERAL_NOBACKUP) || iniConfig.General.noBackup
+    },
+
+    Network: {
+        port: process.env.TRILIUM_NETWORK_PORT || iniConfig.Network.port,
+        https: envToBoolean(process.env.TRILIUM_NETWORK_HTTPS) || iniConfig.Network.https,
+        certPath: process.env.TRILIUM_NETWORK_CERTPATH  || iniConfig.Network.certPath,
+        keyPath: process.env.TRILIUM_NETWORK_KEYPATH  || iniConfig.Network.keyPath,
+        trustedReverseProxy: process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy
+    }
+
+};
+
 
 export default config;

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -17,7 +17,28 @@ if (!fs.existsSync(dataDir.CONFIG_INI_PATH)) {
 
 const iniConfig = ini.parse(fs.readFileSync(dataDir.CONFIG_INI_PATH, "utf-8"));
 
-const config = {
+export interface TriliumConfig {
+    General: {
+        instanceName: string;
+        noAuthentication: boolean;
+        noBackup: boolean;
+        noDesktopIcon: boolean;
+    };
+    Network: {
+        host: string;
+        port: string;
+        https: boolean;
+        certPath: string;
+        keyPath: string;
+        trustedReverseProxy: boolean | string;
+    };
+    Sync: {
+        syncServerHost: string;
+        syncServerTimeout: string;
+        syncProxy: string;
+    };
+}
+const config: TriliumConfig = {
 
     General: {
         instanceName: process.env.TRILIUM_GENERAL_INSTANCENAME || iniConfig.General.instanceName,

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -19,7 +19,7 @@ function getRunAtHours(note: BNote): number[] {
 }
 
 function runNotesWithLabel(runAttrValue: string) {
-    const instanceName = config.General ? config.General.instanceName : null;
+    const instanceName = config.General.instanceName;
     const currentHours = new Date().getHours();
     const notes = attributeService.getNotesWithLabel("run", runAttrValue);
 

--- a/src/services/sync_options.ts
+++ b/src/services/sync_options.ts
@@ -17,7 +17,7 @@ function get(name: keyof typeof config.Sync) {
 export default {
     // env variable is the easiest way to guarantee we won't overwrite prod data during development
     // after copying prod document/data directory
-    getSyncServerHost: () => process.env.TRILIUM_SYNC_SERVER_HOST || get("syncServerHost"),
+    getSyncServerHost: () => get("syncServerHost"),
     isSyncSetup: () => {
         const syncServerHost = get("syncServerHost");
 

--- a/src/services/sync_options.ts
+++ b/src/services/sync_options.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import optionService from "./options.js";
-import type { OptionNames } from "./options_interface.js";
 import config from "./config.js";
 
 /*
@@ -11,8 +10,8 @@ import config from "./config.js";
  * to live sync server.
  */
 
-function get(name: OptionNames) {
-    return (config["Sync"] && config["Sync"][name]) || optionService.getOption(name);
+function get(name: keyof typeof config.Sync) {
+  return (config["Sync"] && config["Sync"][name]) || optionService.getOption(name);
 }
 
 export default {

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -295,6 +295,18 @@ export function isString(x: any) {
     return Object.prototype.toString.call(x) === "[object String]";
 }
 
+// try to turn 'true' and 'false' strings from process.env variables into boolean values or undefined
+export function envToBoolean(val: string | undefined) {
+    if (val === undefined || typeof val !== "string") return undefined;
+
+    const valLc = val.toLowerCase().trim();
+
+    if (valLc === "true") return true;
+    if (valLc === "false") return false;
+
+    return undefined;
+}
+
 /**
  * Returns the directory for resources. On Electron builds this corresponds to the `resources` subdirectory inside the distributable package.
  * On development builds, this simply refers to the root directory of the application.
@@ -352,5 +364,6 @@ export default {
     isString,
     getResourceDir,
     isMac,
-    isWindows
+    isWindows,
+    envToBoolean
 };


### PR DESCRIPTION
Hi,

this PR is a continuation of @perfectra1n's PR https://github.com/TriliumNext/Notes/pull/1031

It allows users to set the currently defined values via env variables (new!), config.ini (as before) or use fallback values (semi-new!).

The order is:
ENV > config.ini > fallback values

as @perfectra1n mentioned in the matrix Development channel, there still are a couple of env vars, scattered around, that are currently not part of this config file.
Let's split that out into a separate task though – this PR only concentrates on the ones that can be mapped to values in the config.ini file

Also some additional clean up will be necessary, e.g. in port.ts, but will split that out to separate task as well.

big thanks to @perfectra1n for letting me take over here!