### PR TITLE
fix(webpack): add missing share.js entry point

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -8,7 +8,8 @@ export default {
     entry: {
         setup: "./src/public/app/setup.js",
         mobile: "./src/public/app/mobile.js",
-        desktop: "./src/public/app/desktop.js"
+        desktop: "./src/public/app/desktop.js",
+        share: "./src/public/app/share.js"
     },
     output: {
         publicPath: `${assetPath}/app-dist/`,


### PR DESCRIPTION
Hi,

this PR fixes the missing share.js entry point that causes a missing share.js file error, when using dev mode.

this is partially related to TriliumNext/trilium#5428, but does not seem to entirely fix the issue in production – that is a different cause.
This at least gets rid of the error described here: 
https://github.com/TriliumNext/trilium/issues/5428

<del>Edit: kindly hold this back for a moment, something seems off with my change :-)</del> edit2: all good :-)
