### PR TITLE
chore(webpack): add Configuration type

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,9 +1,10 @@
 import { fileURLToPath } from "url";
 import path from "path";
 import assetPath from "./src/services/asset_path.js";
+import type { Configuration } from "webpack";
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url));
-export default {
+const config: Configuration = {
     mode: "production",
     entry: {
         setup: "./src/public/app/setup.js",
@@ -42,3 +43,5 @@ export default {
     devtool: "source-map",
     target: "electron-renderer"
 };
+
+export default config;


### PR DESCRIPTION
Hi,

this just simply adds the Configuration Type from webpack to the webpack.config.ts -> allows for intellisense in e.g. VSCode, so makes it a bit easier to work with the file :-)