### PR TITLE
chore: make share.js work with webpack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN cp -R build/src/* src/. && \
     npm run webpack && \
     npm prune --omit=dev && \
     npm cache clean --force && \
-    cp src/public/app/share.js src/public/app-dist/. && \
     cp -r src/public/app/doc_notes src/public/app-dist/. && \
     rm -rf src/public/app/* && \
     mkdir -p src/public/app/services && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,7 +27,6 @@ RUN cp -R build/src/* src/. && \
     npm run webpack && \
     npm prune --omit=dev && \
     npm cache clean --force && \
-    cp src/public/app/share.js src/public/app-dist/. && \
     cp -r src/public/app/doc_notes src/public/app-dist/. && \
     rm -rf src/public/app && \
     mkdir -p src/public/app/services && \

--- a/bin/copy-trilium.sh
+++ b/bin/copy-trilium.sh
@@ -68,7 +68,6 @@ find $DIR -name "*.ts" -type f -delete
 
 d="$DIR"/src/public
 [[ -d "$d"/app-dist ]] || mkdir -pv "$d"/app-dist
-cp "$d"/app/share.js "$d"/app-dist/
 cp -r "$d"/app/doc_notes "$d"/app-dist/
 
 rm -rf "$d"/app

--- a/src/public/app/share.ts
+++ b/src/public/app/share.ts
@@ -3,7 +3,7 @@
  *
  * @param noteId of the given note to be fetched. If false, fetches current note.
  */
-async function fetchNote(noteId = null) {
+async function fetchNote(noteId: string | null = null) {
     if (!noteId) {
         noteId = document.body.getAttribute("data-note-id");
     }

--- a/src/public/app/share.ts
+++ b/src/public/app/share.ts
@@ -25,3 +25,9 @@ document.addEventListener(
     },
     false
 );
+
+// workaround to prevent webpack from removing "fetchNote" as dead code:
+// add fetchNote as property to the window object
+Object.defineProperty(window, "fetchNote", {
+    value: fetchNote
+});


### PR DESCRIPTION
Hi,

this PR allows for webpack to take care of the share.js file – without losing the "fetchNote" functionality.
This involves a small "workaround" in the share.js, to avoid Webpack from treating it as dead code – I was trying to get the same result by using webpack config flags, but was not able to get the correct results.


Since we now have webpack taking care of the share.js:
* we can port it to TS (which I did here as well)
* we can get rid of the manual copying of the file in the Dockerfile and the copy-trilium.sh build scripts.


this also should fix #1029 