### PR TITLE
build(npm): use specific overrides instead of `legacy-peer-deps`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-prefix = ''
-legacy-peer-deps = true

--- a/package.json
+++ b/package.json
@@ -211,5 +211,10 @@
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1",
     "webpack-dev-middleware": "7.4.2"
+  },
+  "overrides": {
+    "@mind-elixir/node-menu": {
+      "mind-elixir": "$mind-elixir"
+    }
   }
 }


### PR DESCRIPTION
Hi,

this PR removes the default setting of using `legacy-peer-deps` in .npmrc, and instead adds an override section in package.json.
This allows us to handle these peer dependency issues on a case by case basis, instead of generally allowing it for all packages, which could lead to unnoticed issues.

Using  `legacy-peer-deps` is [not recommended  ](https://docs.npmjs.com/cli/v7/using-npm/config#legacy-peer-deps)

In our specific case the `@mind-elixir/node-menu` package is the only package that currently causes peerDep issues, as
it still using mind-elixir 2.x.x as peerDep, which cannot be resolved, since we use v4.
Upstream issue to properly resolve the issue was also created https://github.com/SSShooter/node-menu/issues/4