### PR TITLE
chore: delete outdated issue_template.md

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,5 +1,0 @@
-For bug reports, **PLEASE mention version of Trilium you're using** and also include **log files** from following location:
-
-* `/home/[user]/.local/share/trilium-data/log` for Linux
-* `C:\Users\[user]\AppData\Roaming\trilium-data\log` for Windows Vista and up
-* `/Users/[user]/Library/Application Support/trilium-data/log` for Mac OS


### PR DESCRIPTION
chore: delete outdated issue_template.md, the current ones are already existing under `.github`