### PR TITLE
chore(issue_templates): Use new type field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug Report
 description: Report a bug
-title: "(Bug report) "
-labels: "Type: Bug"
+type: "Bug"
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,11 @@
 name: Feature Request
 description: Ask for a new feature to be added
-title: "(Feature request) "
-labels: "Type: Enhancement"
+type: "Feature"
 body:
 - type: textarea
   attributes:
     label: Describe feature
-    description: A clear and concise description of what you want to be added..
+    description: A clear and concise description of what you want to be added.
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Let's make use of the type field for the issues:

https://github.com/orgs/community/discussions/148715#discussioncomment-11845050

Since the "bug" and "feature" labels have also been removed, I've removed them from the yml as well :-)