### PR TITLE
refactor(server/utils): turn isMac/isWin/isElectron/isDev into boolean

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,7 +35,7 @@ app.use((req, res, next) => {
     return next();
 });
 
-if (!utils.isElectron()) {
+if (!utils.isElectron) {
     app.use(compression()); // HTTP compression
 }
 
@@ -77,7 +77,7 @@ await import("./services/scheduler.js");
 
 startScheduledCleanup();
 
-if (utils.isElectron()) {
+if (utils.isElectron) {
     (await import("@electron/remote/main/index.js")).initialize();
 }
 

--- a/src/routes/api/clipper.ts
+++ b/src/routes/api/clipper.ts
@@ -195,7 +195,7 @@ function processContent(images: Image[], note: BNote, content: string) {
 }
 
 function openNote(req: Request) {
-    if (utils.isElectron()) {
+    if (utils.isElectron) {
         ws.sendMessageToAllClients({
             type: "openNote",
             noteId: req.params.noteId

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -181,7 +181,7 @@ function saveToTmpDir(fileName: string, content: string | Buffer, entityType: st
 
     log.info(`Saved temporary file ${tmpObj.name}`);
 
-    if (utils.isElectron()) {
+    if (utils.isElectron) {
         chokidar.watch(tmpObj.name).on("change", (path, stats) => {
             ws.sendMessageToAllClients({
                 type: "openedFileUpdated",

--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -2,11 +2,11 @@ import assetPath from "../services/asset_path.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import express from "express";
-import env from "../services/env.js";
+import { isDev } from "../services/utils.js";
 import type serveStatic from "serve-static";
 
 const persistentCacheStatic = (root: string, options?: serveStatic.ServeStaticOptions<express.Response<any, Record<string, any>>>) => {
-    if (!env.isDev()) {
+    if (!isDev) {
         options = {
             maxAge: "1y",
             ...options
@@ -17,7 +17,7 @@ const persistentCacheStatic = (root: string, options?: serveStatic.ServeStaticOp
 
 async function register(app: express.Application) {
     const srcRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
-    if (env.isDev()) {
+    if (isDev) {
         const webpack = (await import("webpack")).default;
         const webpackMiddleware = (await import("webpack-dev-middleware")).default;
         const productionConfig = (await import("../../webpack.config.js")).default;

--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -8,7 +8,7 @@ const doubleCsrfUtilities = doubleCsrf({
         path: "", // empty, so cookie is valid only for the current path
         secure: false,
         sameSite: "strict",
-        httpOnly: !isElectron() // set to false for Electron, see https://github.com/TriliumNext/Notes/pull/966
+        httpOnly: !isElectron // set to false for Electron, see https://github.com/TriliumNext/Notes/pull/966
     },
     cookieName: "_csrf"
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,7 +6,7 @@ import config from "../services/config.js";
 import optionService from "../services/options.js";
 import log from "../services/log.js";
 import env from "../services/env.js";
-import utils from "../services/utils.js";
+import { isElectron } from "../services/utils.js";
 import protectedSessionService from "../services/protected_session.js";
 import packageJson from "../../package.json" with { type: "json" };
 import assetPath from "../services/asset_path.js";
@@ -19,7 +19,7 @@ import type BNote from "../becca/entities/bnote.js";
 function index(req: Request, res: Response) {
     const options = optionService.getOptionMap();
 
-    const view = !utils.isElectron() && req.cookies["trilium-device"] === "mobile" ? "mobile" : "desktop";
+    const view = !isElectron && req.cookies["trilium-device"] === "mobile" ? "mobile" : "desktop";
 
     //'overwrite' set to false (default) => the existing token will be re-used and validated
     //'validateOnReuse' set to false => if validation fails, generate a new token instead of throwing an error
@@ -34,7 +34,6 @@ function index(req: Request, res: Response) {
     const theme = options.theme;
     const themeNote = attributeService.getNoteWithLabel("appTheme", theme);
 
-    const isElectron = utils.isElectron();
     res.render(view, {
         device: view,
         csrfToken: csrfToken,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,8 +5,7 @@ import attributeService from "../services/attributes.js";
 import config from "../services/config.js";
 import optionService from "../services/options.js";
 import log from "../services/log.js";
-import env from "../services/env.js";
-import { isElectron } from "../services/utils.js";
+import { isDev, isElectron } from "../services/utils.js";
 import protectedSessionService from "../services/protected_session.js";
 import packageJson from "../../package.json" with { type: "json" };
 import assetPath from "../services/asset_path.js";
@@ -52,7 +51,7 @@ function index(req: Request, res: Response) {
         maxEntityChangeSyncIdAtLoad: sql.getValue("SELECT COALESCE(MAX(id), 0) FROM entity_changes WHERE isSynced = 1"),
         instanceName: config.General ? config.General.instanceName : null,
         appCssNoteIds: getAppCssNoteIds(),
-        isDev: env.isDev(),
+        isDev,
         isMainWindow: view === "mobile" ? true : !req.query.extraWindow,
         isProtectedSessionAvailable: protectedSessionService.isProtectedSessionAvailable(),
         maxContentWidth: Math.max(640, parseInt(options.maxContentWidth)),

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import utils from "../services/utils.js";
+import { isElectron } from "../services/utils.js";
 import multer from "multer";
 import log from "../services/log.js";
 import express from "express";
@@ -280,7 +280,7 @@ function register(app: express.Application) {
     apiRoute(DEL, "/api/etapi-tokens/:etapiTokenId", etapiTokensApiRoutes.deleteToken);
 
     // in case of local electron, local calls are allowed unauthenticated, for server they need auth
-    const clipperMiddleware = utils.isElectron() ? [] : [auth.checkEtapiToken];
+    const clipperMiddleware = isElectron ? [] : [auth.checkEtapiToken];
 
     route(GET, "/api/clipper/handshake", clipperMiddleware, clipperRoute.handshake, apiResultHandler);
     route(PST, "/api/clipper/clippings", clipperMiddleware, clipperRoute.addClipping, apiResultHandler);

--- a/src/routes/setup.ts
+++ b/src/routes/setup.ts
@@ -2,14 +2,14 @@
 
 import sqlInit from "../services/sql_init.js";
 import setupService from "../services/setup.js";
-import utils from "../services/utils.js";
+import { isElectron } from "../services/utils.js";
 import assetPath from "../services/asset_path.js";
 import appPath from "../services/app_path.js";
 import type { Request, Response } from "express";
 
 function setupPage(req: Request, res: Response) {
     if (sqlInit.isDbInitialized()) {
-        if (utils.isElectron()) {
+        if (isElectron) {
             handleElectronRedirect();
         } else {
             res.redirect(".");

--- a/src/services/app_icon.ts
+++ b/src/services/app_icon.ts
@@ -23,7 +23,7 @@ Terminal=false
  * We overwrite this file during every run as it might have been updated.
  */
 function installLocalAppIcon() {
-    if (!isElectron() || ["win32", "darwin"].includes(os.platform()) || (config.General && config.General.noDesktopIcon)) {
+    if (!isElectron || ["win32", "darwin"].includes(os.platform()) || (config.General && config.General.noDesktopIcon)) {
         return;
     }
 

--- a/src/services/app_path.ts
+++ b/src/services/app_path.ts
@@ -1,4 +1,4 @@
 import assetPath from "./asset_path.js";
-import env from "./env.js";
+import { isDev } from "./utils.js";
 
-export default env.isDev() ? assetPath + "/app" : assetPath + "/app-dist";
+export default isDev ? assetPath + "/app" : assetPath + "/app-dist";

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -14,7 +14,7 @@ const noAuthentication = config.General && config.General.noAuthentication === t
 function checkAuth(req: Request, res: Response, next: NextFunction) {
     if (!sqlInit.isDbInitialized()) {
         res.redirect("setup");
-    } else if (!req.session.loggedIn && !isElectron() && !noAuthentication) {
+    } else if (!req.session.loggedIn && !isElectron && !noAuthentication) {
         res.redirect("login");
     } else {
         next();
@@ -24,7 +24,7 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
 // for electron things which need network stuff
 //  currently, we're doing that for file upload because handling form data seems to be difficult
 function checkApiAuthOrElectron(req: Request, res: Response, next: NextFunction) {
-    if (!req.session.loggedIn && !isElectron() && !noAuthentication) {
+    if (!req.session.loggedIn && !isElectron && !noAuthentication) {
         reject(req, res, "Logged in session not found");
     } else {
         next();
@@ -48,7 +48,7 @@ function checkAppInitialized(req: Request, res: Response, next: NextFunction) {
 }
 
 function checkPasswordSet(req: Request, res: Response, next: NextFunction) {
-    if (!isElectron() && !passwordService.isPasswordSet()) {
+    if (!isElectron && !passwordService.isPasswordSet()) {
         res.redirect("set-password");
     } else {
         next();
@@ -56,7 +56,7 @@ function checkPasswordSet(req: Request, res: Response, next: NextFunction) {
 }
 
 function checkPasswordNotSet(req: Request, res: Response, next: NextFunction) {
-    if (!isElectron() && passwordService.isPasswordSet()) {
+    if (!isElectron && passwordService.isPasswordSet()) {
         res.redirect("login");
     } else {
         next();

--- a/src/services/code_block_theme.ts
+++ b/src/services/code_block_theme.ts
@@ -8,8 +8,7 @@ import fs from "fs";
 import themeNames from "./code_block_theme_names.json" with { type: "json" };
 import { t } from "i18next";
 import { join } from "path";
-import { isElectron, getResourceDir } from "./utils.js";
-import env from "./env.js";
+import { isDev, isElectron, getResourceDir } from "./utils.js";
 
 /**
  * Represents a color scheme for the code block syntax highlight.
@@ -46,7 +45,7 @@ export function listSyntaxHighlightingThemes() {
 }
 
 function getStylesDirectory() {
-    if (isElectron() && !env.isDev()) {
+    if (isElectron && !isDev) {
         return "styles";
     }
 

--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -1,7 +1,0 @@
-function isDev() {
-    return !!(process.env.TRILIUM_ENV && process.env.TRILIUM_ENV === "dev");
-}
-
-export default {
-    isDev
-};

--- a/src/services/keyboard_actions.ts
+++ b/src/services/keyboard_actions.ts
@@ -2,11 +2,10 @@
 
 import optionService from "./options.js";
 import log from "./log.js";
-import { isElectron as getIsElectron, isMac as getIsMac } from "./utils.js";
+import { isElectron as getIsElectron, isMac } from "./utils.js";
 import type { KeyboardShortcut } from "./keyboard_actions_interface.js";
 import { t } from "i18next";
 
-const isMac = getIsMac();
 const isElectron = getIsElectron();
 
 function getDefaultKeyboardActions() {

--- a/src/services/keyboard_actions.ts
+++ b/src/services/keyboard_actions.ts
@@ -2,11 +2,9 @@
 
 import optionService from "./options.js";
 import log from "./log.js";
-import { isElectron as getIsElectron, isMac } from "./utils.js";
+import { isElectron, isMac } from "./utils.js";
 import type { KeyboardShortcut } from "./keyboard_actions_interface.js";
 import { t } from "i18next";
-
-const isElectron = getIsElectron();
 
 function getDefaultKeyboardActions() {
     if (!t("keyboard_actions.note-navigation")) {

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -17,7 +17,7 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
-const NEW_LINE = isWindows() ? "\r\n" : "\n";
+const NEW_LINE = isWindows ? "\r\n" : "\n";
 
 let todaysMidnight!: Date;
 

--- a/src/services/options_init.ts
+++ b/src/services/options_init.ts
@@ -77,7 +77,7 @@ const defaultOptions: DefaultOption[] = [
     { name: "revisionSnapshotTimeInterval", value: "600", isSynced: true },
     { name: "revisionSnapshotNumberLimit", value: "-1", isSynced: true },
     { name: "protectedSessionTimeout", value: "600", isSynced: true },
-    { name: "zoomFactor", value: isWindows() ? "0.9" : "1.0", isSynced: false },
+    { name: "zoomFactor", value: isWindows ? "0.9" : "1.0", isSynced: false },
     { name: "overrideThemeFonts", value: "false", isSynced: false },
     { name: "mainFontFamily", value: "theme", isSynced: false },
     { name: "mainFontSize", value: "100", isSynced: false },

--- a/src/services/port.ts
+++ b/src/services/port.ts
@@ -18,7 +18,7 @@ let port: number;
 
 if (process.env.TRILIUM_PORT) {
     port = parseAndValidate(process.env.TRILIUM_PORT, "environment variable TRILIUM_PORT");
-} else if (isElectron()) {
+} else if (isElectron) {
     port = env.isDev() ? 37740 : 37840;
 } else {
     port = parseAndValidate(config["Network"]["port"] || "3000", `Network.port in ${dataDir.CONFIG_INI_PATH}`);

--- a/src/services/port.ts
+++ b/src/services/port.ts
@@ -1,6 +1,5 @@
 import config from "./config.js";
-import { isElectron } from "./utils.js";
-import env from "./env.js";
+import { isDev, isElectron } from "./utils.js";
 import dataDir from "./data_dir.js";
 
 function parseAndValidate(portStr: string, source: string) {
@@ -19,7 +18,7 @@ let port: number;
 if (process.env.TRILIUM_PORT) {
     port = parseAndValidate(process.env.TRILIUM_PORT, "environment variable TRILIUM_PORT");
 } else if (isElectron) {
-    port = env.isDev() ? 37740 : 37840;
+    port = isDev ? 37740 : 37840;
 } else {
     port = parseAndValidate(config["Network"]["port"] || "3000", `Network.port in ${dataDir.CONFIG_INI_PATH}`);
 }

--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -206,7 +206,7 @@ async function getProxyAgent(opts: ClientOpts) {
 async function getClient(opts: ClientOpts): Promise<Client> {
     // it's not clear how to explicitly configure proxy (as opposed to system proxy),
     // so in that case, we always use node's modules
-    if (isElectron() && !opts.proxy) {
+    if (isElectron && !opts.proxy) {
         return (await import("electron")).net as Client;
     } else {
         const { protocol } = url.parse(opts.url);

--- a/src/services/sql_init.ts
+++ b/src/services/sql_init.ts
@@ -37,7 +37,7 @@ function isDbInitialized() {
 
 async function initDbConnection() {
     if (!isDbInitialized()) {
-        log.info(`DB not initialized, please visit setup page` + (isElectron() ? "" : ` - http://[your-server-host]:${port} to see instructions on how to initialize Trilium.`));
+        log.info(`DB not initialized, please visit setup page` + (isElectron ? "" : ` - http://[your-server-host]:${port} to see instructions on how to initialize Trilium.`));
 
         return;
     }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -8,7 +8,6 @@ import sanitize from "sanitize-filename";
 import mimeTypes from "mime-types";
 import path from "path";
 import { fileURLToPath } from "url";
-import env from "./env.js";
 import { dirname, join } from "path";
 
 const randtoken = generator({ source: "crypto" });
@@ -18,6 +17,8 @@ export const isMac = process.platform === "darwin";
 export const isWindows = process.platform === "win32";
 
 export const isElectron = !!process.versions["electron"];
+
+export const isDev = !!(process.env.TRILIUM_ENV && process.env.TRILIUM_ENV === "dev");
 
 export function newEntityId() {
     return randomString(12);
@@ -316,7 +317,7 @@ export function envToBoolean(val: string | undefined) {
  * @returns the resource dir.
  */
 export function getResourceDir() {
-    if (isElectron && !env.isDev()) {
+    if (isElectron && !isDev) {
         return process.resourcesPath;
     } else {
         return join(dirname(fileURLToPath(import.meta.url)), "..", "..");

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -13,6 +13,12 @@ import { dirname, join } from "path";
 
 const randtoken = generator({ source: "crypto" });
 
+export const isMac = process.platform === "darwin";
+
+export const isWindows = process.platform === "win32";
+
+export const isElectron = !!process.versions["electron"];
+
 export function newEntityId() {
     return randomString(12);
 }
@@ -56,10 +62,6 @@ export function hmac(secret: any, value: any) {
     const hmac = crypto.createHmac("sha256", Buffer.from(secret.toString(), "ascii"));
     hmac.update(value.toString());
     return hmac.digest("base64");
-}
-
-export function isElectron() {
-    return !!process.versions["electron"];
 }
 
 export function hash(text: string) {
@@ -128,7 +130,7 @@ export function escapeRegExp(str: string) {
 }
 
 export async function crash() {
-    if (isElectron()) {
+    if (isElectron) {
         (await import("electron")).app.exit(1);
     } else {
         process.exit(1);
@@ -314,17 +316,11 @@ export function envToBoolean(val: string | undefined) {
  * @returns the resource dir.
  */
 export function getResourceDir() {
-    if (isElectron() && !env.isDev()) {
+    if (isElectron && !env.isDev()) {
         return process.resourcesPath;
     } else {
         return join(dirname(fileURLToPath(import.meta.url)), "..", "..");
     }
-}
-
-export const isMac = process.platform === "darwin";
-
-export const isWindows = process.platform === "win32";
-    return process.platform === "win32";
 }
 
 export default {

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -321,11 +321,9 @@ export function getResourceDir() {
     }
 }
 
-export function isMac() {
-    return process.platform === "darwin";
-}
+export const isMac = process.platform === "darwin";
 
-export function isWindows() {
+export const isWindows = process.platform === "win32";
     return process.platform === "win32";
 }
 

--- a/src/services/window.ts
+++ b/src/services/window.ts
@@ -2,7 +2,6 @@ import path from "path";
 import url from "url";
 import port from "./port.js";
 import optionService from "./options.js";
-import env from "./env.js";
 import log from "./log.js";
 import sqlInit from "./sql_init.js";
 import cls from "./cls.js";
@@ -10,7 +9,7 @@ import keyboardActionsService from "./keyboard_actions.js";
 import remoteMain from "@electron/remote/main/index.js";
 import type { App, BrowserWindow, BrowserWindowConstructorOptions, WebContents } from "electron";
 import { ipcMain } from "electron";
-import { isMac, isWindows } from "./utils.js";
+import { isDev, isMac, isWindows } from "./utils.js";
 
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -169,7 +168,7 @@ function configureWebContents(webContents: WebContents, spellcheckEnabled: boole
 }
 
 function getIcon() {
-    return path.join(dirname(fileURLToPath(import.meta.url)), "../../images/app-icons/png/256x256" + (env.isDev() ? "-dev" : "") + ".png");
+    return path.join(dirname(fileURLToPath(import.meta.url)), "../../images/app-icons/png/256x256" + (isDev ? "-dev" : "") + ".png");
 }
 
 async function createSetupWindow() {

--- a/src/services/window.ts
+++ b/src/services/window.ts
@@ -116,10 +116,10 @@ function getWindowExtraOpts() {
     const extraOpts: Partial<BrowserWindowConstructorOptions> = {};
 
     if (!optionService.getOptionBool("nativeTitleBarVisible")) {
-        if (isMac()) {
+        if (isMac) {
             extraOpts.titleBarStyle = "hiddenInset";
             extraOpts.titleBarOverlay = true;
-        } else if (isWindows()) {
+        } else if (isWindows) {
             extraOpts.titleBarStyle = "hidden";
             extraOpts.titleBarOverlay = true;
         } else {
@@ -129,7 +129,7 @@ function getWindowExtraOpts() {
     }
 
     // Window effects (Mica)
-    if (optionService.getOptionBool("backgroundEffects") && isWindows()) {
+    if (optionService.getOptionBool("backgroundEffects") && isWindows) {
         extraOpts.backgroundMaterial = "auto";
     }
 

--- a/src/services/ws.ts
+++ b/src/services/ws.ts
@@ -1,5 +1,5 @@
 import { WebSocketServer as WebSocketServer, WebSocket } from "ws";
-import { isElectron, randomString } from "./utils.js";
+import { isDev, isElectron, randomString } from "./utils.js";
 import log from "./log.js";
 import sql from "./sql.js";
 import cls from "./cls.js";
@@ -9,11 +9,10 @@ import protectedSessionService from "./protected_session.js";
 import becca from "../becca/becca.js";
 import AbstractBeccaEntity from "../becca/entities/abstract_becca_entity.js";
 
-import env from "./env.js";
 import type { IncomingMessage, Server as HttpServer } from "http";
 import type { EntityChange } from "./entity_changes_interface.js";
 
-if (env.isDev()) {
+if (isDev) {
     const chokidar = (await import("chokidar")).default;
     const debounce = (await import("debounce")).default;
     const debouncedReloadFrontend = debounce(() => reloadFrontend("source code change"), 200);

--- a/src/services/ws.ts
+++ b/src/services/ws.ts
@@ -18,7 +18,7 @@ if (env.isDev()) {
     const debounce = (await import("debounce")).default;
     const debouncedReloadFrontend = debounce(() => reloadFrontend("source code change"), 200);
     chokidar
-        .watch(isElectron() ? "dist/src/public" : "src/public")
+        .watch(isElectron ? "dist/src/public" : "src/public")
         .on("add", debouncedReloadFrontend)
         .on("change", debouncedReloadFrontend)
         .on("unlink", debouncedReloadFrontend);
@@ -62,7 +62,7 @@ function init(httpServer: HttpServer, sessionParser: SessionParser) {
     webSocketServer = new WebSocketServer({
         verifyClient: (info, done) => {
             sessionParser(info.req, {}, () => {
-                const allowed = isElectron() || (info.req as any).session.loggedIn || (config.General && config.General.noAuthentication);
+                const allowed = isElectron || (info.req as any).session.loggedIn || (config.General && config.General.noAuthentication);
 
                 if (!allowed) {
                     log.error("WebSocket connection not allowed because session is neither electron nor logged in.");

--- a/src/www.ts
+++ b/src/www.ts
@@ -53,7 +53,7 @@ async function startTrilium() {
      * its startup is slower than focusing the existing process/window. So in the end, it works out without having
      * to do a complex evaluation.
      */
-    if (utils.isElectron()) {
+    if (utils.isElectron) {
         (await import("electron")).app.requestSingleInstanceLock();
     }
 
@@ -71,7 +71,7 @@ async function startTrilium() {
 
     ws.init(httpServer, sessionParser as any); // TODO: Not sure why session parser is incompatible.
 
-    if (utils.isElectron()) {
+    if (utils.isElectron) {
         const electronRouting = await import("./routes/electron.js");
         electronRouting.default(app);
     }
@@ -146,7 +146,7 @@ function startHttpServer() {
             }
         }
 
-        if (utils.isElectron()) {
+        if (utils.isElectron) {
             import("electron").then(({ app, dialog }) => {
                 // Not all situations require showing an error dialog. When Trilium is already open,
                 // clicking the shortcut, the software icon, or the taskbar icon, or when creating a new window,


### PR DESCRIPTION
Hi,

this PR replaces the  isMac/isWin/isElectron/isDev functions that are returning a boolean.

These values cannot change during runtime under any **normal** circumstances (i.e. the process will never suddenly switch from a "win32" platform to a "darwin" platform midst execution, or the process.env value will not change, unless we do something sketchy during runtime).

→ There is no need to have these checks as functions – instead just do the check once and export and reuse those values directly.

Let's us save some computing power (admittedly it'll be a *very very* tiny bit) ;-)