### PR TITLE
Fix a bug in the full text search in AutoComplete

### DIFF
--- a/src/public/app/services/note_autocomplete.ts
+++ b/src/public/app/services/note_autocomplete.ts
@@ -131,7 +131,6 @@ function fullTextSearch($el: JQuery<HTMLElement>, options: Options) {
     $el.trigger("focus");
     options.fastSearch = false;
     $el.autocomplete("val", "");
-    $el.autocomplete();
     $el.setSelectedNotePath("");
     $el.autocomplete("val", searchString);
     // Set a delay to avoid resetting to true before full text search (await server.get) is called.


### PR DESCRIPTION
`$el.autocomplete();` will cause full-text search to malfunction. If this line is included, clicking full-text search will result in an error, and the search will not be triggered：
![图片](https://github.com/user-attachments/assets/d40d6e3a-f3b0-457a-8a40-a0a60b82c92d)

After removing this line of code, clicking full-text search works correctly：
![图片](https://github.com/user-attachments/assets/bca322e9-1415-448b-a96f-9be0a7a9050a)

