### PR TITLE
Band-Aid fix for the bootleg eslint

### DIFF
--- a/libraries/codemirror/eslint.js
+++ b/libraries/codemirror/eslint.js
@@ -46,7 +46,7 @@
         const errors = new eslint().verify(text, {
             root: true,
             parserOptions: {
-                ecmaVersion: "latest"
+                ecmaVersion: "2019"
             },
             extends: ['eslint:recommended', 'airbnb-base'],
             env: {


### PR DESCRIPTION
not sure why 'latest' is not working, but this fixes the annoying errors related to es5 being default for parsing.

Anything more recent than 2019 does not work unfortunately.