### PR TITLE
refactor(bin/electron-forge): make desktop.ejs easier to read

### DIFF
--- a/bin/electron-forge/desktop.ejs
+++ b/bin/electron-forge/desktop.ejs
@@ -1,12 +1,17 @@
 [Desktop Entry]
-<% if (productName) { %>Name=<%= productName %>
-<% } %><% if (description) { %>Comment=<%= description %>
-<% } %><% if (genericName) { %>GenericName=<%= genericName %>
-<% } %><% if (name) { %>Exec=<%= name %> %U
-Icon=<%= name %>
-<% } %>Type=Application
-StartupNotify=true
-<% if (productName) { %>StartupWMClass=<%= productName %>
-<% } if (categories && categories.length) { %>Categories=<%= categories.join(';') %>;
-<% } %><% if (mimeType && mimeType.length) { %>MimeType=<%= mimeType.join(';') %>;
-<% } %>
+<%=
+Object.entries({
+    "Name": productName,
+    "Comment": description,
+    "GenericName": genericName,
+    "Exec": name ? `${name} %U` : undefined,
+    "Icon": name,
+    "Type": "Application",
+    "StartupNotify": "true",
+    "StartupWMClass": productName,
+    "Categories": categories?.length ? `${categories.join(";")};` : undefined,
+    "MimeType": mimeType?.length ? `${mimeType.join(";")};` : undefined
+})
+.map(line => line[1] ? line.join("=") : undefined)
+.filter(line => !!line)
+.join("\n")%>


### PR DESCRIPTION
Hi,

This PR aims to make the desktop.ejs template that is used for the Linux packages *a lot* easier to read.
We just define the lines as an Array tuple, and then filter out any values, which are falsy (or in this case undefined), before joining them with a "\n" new line.

electron-forge correctly packages the file and its output is identical to the previous template
![grafik](https://github.com/user-attachments/assets/88a82cbf-9b0b-472b-9755-40cc123c0837)


I admit, this a tiny bit of a useless refactor, but it still irked me to see that file in its previous state :-D