### PR TITLE
build: add flatpak build via electron-forge

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -15,10 +15,15 @@ runs:
       if: ${{ inputs.os == 'macos' }}
       shell: bash
       run: brew install python-setuptools
-    - name: Install rpm on Ubuntu for RPM package building
+    - name: Install dependencies for RPM and Flatpak package building
       if: ${{ inputs.os == 'linux' }}
       shell: bash
-      run: sudo apt install rpm
+      run: |
+        sudo apt-get update && sudo apt-get install rpm flatpak-builder elfutils
+        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        FLATPAK_ARCH=$(if [[ ${{ inputs.arch }} = 'arm64' ]]; then echo 'aarch64'; else echo 'x86_64'; fi)
+        FLATPAK_VERSION='24.08'
+        flatpak install --user --no-deps --arch $FLATPAK_ARCH --assumeyes runtime/org.freedesktop.Platform/$FLATPAK_ARCH/$FLATPAK_VERSION runtime/org.freedesktop.Sdk/$FLATPAK_ARCH/$FLATPAK_VERSION org.electronjs.Electron2.BaseApp/$FLATPAK_ARCH/$FLATPAK_VERSION
     - name: Install dependencies
       shell: bash
       run: npm ci

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -27,6 +27,10 @@ runs:
     - name: Install dependencies
       shell: bash
       run: npm ci
+    - name: Temporary Flatpak arm64 workaround till https://github.com/electron/forge/pull/3839 is merged
+      if: ${{ inputs.os == 'linux' && inputs.arch == 'arm64' }}
+      shell: bash
+      run:  sed -e "s/case 'armv7l'/case 'arm64'/g" -e "s/return 'arm'/return 'aarch64'/g" -i node_modules/@electron-forge/maker-flatpak/dist/MakerFlatpak.js
     - name: Update build info
       shell: bash
       run: npm run update-build-info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
             extension: [dmg, zip]
           - name: linux
             image: ubuntu-latest
-            extension: [deb, rpm, zip]
+            extension: [deb, rpm, zip, flatpak]
           - name: windows
             image: windows-latest
             extension: exe
@@ -53,6 +53,7 @@ jobs:
         with:
           name: TriliumNextNotes ${{ matrix.os.name }} ${{ matrix.arch }}.${{matrix.os.extension}}
           path: upload/*.${{ matrix.os.extension }}
+
   build_linux_server:
     name: Build Linux Server
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
             extension: [dmg, zip]
           - name: linux
             image: ubuntu-latest
-            extension: [deb, rpm, zip]
+            extension: [deb, rpm, zip, flatpak]
           - name: windows
             image: windows-latest
             extension: exe
@@ -56,6 +56,7 @@ jobs:
           files: upload/*.*
           tag_name: nightly
           name: Nightly Build
+
   nightly-server:
     name: Deploy server nightly
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             extension: [dmg, zip]
           - name: linux
             image: ubuntu-latest
-            extension: [deb, rpm, zip]
+            extension: [deb, rpm, zip, flatpak]
           - name: windows
             image: windows-latest
             extension: exe
@@ -46,6 +46,7 @@ jobs:
           draft: true
           fail_on_unmatched_files: true
           files: upload/*.*
+
   build_linux_server-x64:
     name: Build Linux Server
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ src/public/app-dist/
 npm-debug.log
 yarn-error.log
 po-*/
+.flatpak-builder/
 
 *.db
 !integration-tests/db/document.db

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -65,6 +65,21 @@ module.exports = {
                 options: {
                     icon: "./images/app-icons/png/128x128.png",
                     desktopTemplate: path.resolve("./bin/electron-forge/desktop.ejs"),
+                    id: "com.github.triliumnext.notes",
+                    runtimeVersion: "24.08",
+                    base: "org.electronjs.Electron2.BaseApp",
+                    baseVersion: "24.08",
+                    baseFlatpakref: "https://flathub.org/repo/flathub.flatpakrepo",
+                    modules: [
+                        {
+                            name: "zypak",
+                            sources: {
+                                type: "git",
+                                url: "https://github.com/refi64/zypak",
+                                tag: "v2024.01.17"
+                            }
+                        }
+                    ]
                 },
             }
         },

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -63,8 +63,7 @@ module.exports = {
             name: "@electron-forge/maker-flatpak",
             config: {
                 options: {
-                    icon: "./images/app-icons/png/128x128.png",
-                    desktopTemplate: path.resolve("./bin/electron-forge/desktop.ejs"),
+                    ...baseLinuxMakerConfigOptions,
                     id: "com.github.triliumnext.notes",
                     runtimeVersion: "24.08",
                     base: "org.electronjs.Electron2.BaseApp",

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -60,6 +60,15 @@ module.exports = {
             }
         },
         {
+            name: "@electron-forge/maker-flatpak",
+            config: {
+                options: {
+                    icon: "./images/app-icons/png/128x128.png",
+                    desktopTemplate: path.resolve("./bin/electron-forge/desktop.ejs"),
+                },
+            }
+        },
+        {
             name: "@electron-forge/maker-rpm",
             config: {
                 options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "@electron-forge/cli": "7.6.1",
         "@electron-forge/maker-deb": "7.6.1",
         "@electron-forge/maker-dmg": "7.6.1",
+        "@electron-forge/maker-flatpak": "7.6.1",
         "@electron-forge/maker-rpm": "7.6.1",
         "@electron-forge/maker-squirrel": "7.6.1",
         "@electron-forge/maker-zip": "7.6.1",
@@ -769,6 +770,52 @@
       }
     },
     "node_modules/@electron-forge/maker-dmg/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron-forge/maker-flatpak": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-7.6.1.tgz",
+      "integrity": "sha512-a9EekF8cNzjizwMs8HObxRii2tkLrTcTNMvWNhQqcJohEkJV81zNOLu9l/OdIMlKQ9cF5SuRvA4/m2bQGfT80w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.6.1",
+        "@electron-forge/shared-types": "7.6.1",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "@malept/electron-installer-flatpak": "^0.11.4"
+      }
+    },
+    "node_modules/@electron-forge/maker-flatpak/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron-forge/maker-flatpak/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
@@ -2750,6 +2797,203 @@
       },
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@malept/electron-installer-flatpak/-/electron-installer-flatpak-0.11.4.tgz",
+      "integrity": "sha512-ZdwhT4WeeJWdnsmALUtQ7bn4pzYVh0Vg+4NnF1S3n3OACc9IWg+B+LxI5gT3XSXIrxogouqkjM6gD8S592awyA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "@malept/flatpak-bundler": "^0.4.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.0",
+        "lodash": "^4.17.15",
+        "semver": "^7.1.1",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "electron-installer-flatpak": "bin/electron-installer-flatpak.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/electron-installer-flatpak/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@mermaid-js/layout-elk": {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@electron-forge/cli": "7.6.1",
     "@electron-forge/maker-deb": "7.6.1",
     "@electron-forge/maker-dmg": "7.6.1",
+    "@electron-forge/maker-flatpak": "7.6.1",
     "@electron-forge/maker-rpm": "7.6.1",
     "@electron-forge/maker-squirrel": "7.6.1",
     "@electron-forge/maker-zip": "7.6.1",


### PR DESCRIPTION
Hi,

this PR adds the ability to build a Flatpak package via Github CI using electron-forge.
arm64 support is currently broken, but a PR is opened at electron-forge, to fix that issue.

What we might need to agree still:
is the ID I've used here "acceptable"? 
`com.github.triliumnext.notes`

The original Trilium was using `com.github.zadam.trilium`


this closes TriliumNext/trilium#5078 