### PR TITLE
build(electron): Add "Office" as category for Desktop file

### DIFF
--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -7,6 +7,7 @@ const extraResourcesForPlatform = getExtraResourcesForPlatform();
 const baseLinuxMakerConfigOptions = {
   icon: "./images/app-icons/png/128x128.png",
   desktopTemplate: path.resolve("./bin/electron-forge/desktop.ejs"),
+  categories: ["Office", "Utility"]
 };
 
 module.exports = {


### PR DESCRIPTION
Hi,

this PR adds "Office" as category for the Linux .desktop file used in the deb, rpm and (soon) flatpak builds.
As per https://specifications.freedesktop.org/menu-spec/latest/category-registry.html

checked with other NoteTaking apps and they all (e.g. Obsidian, Joplin) use "Office" as main category as well, which makes sense here.

I've left the previously used "Utility" (which is used by default) in there as well, though, to not confuse people that might expect to still see it under Utilities