### PR TITLE
chore(ci): improve server build release file names

### DIFF
--- a/.github/actions/build-server/action.yml
+++ b/.github/actions/build-server/action.yml
@@ -25,4 +25,4 @@ runs:
       run: |
         mkdir -p upload
         file=$(find dist -name '*.tar.xz' -print -quit)
-        cp "$file" "upload/TriliumNextNotes-linux-${{ inputs.arch }}-${{ github.ref_name }}.tar.xz"
+        cp "$file" "upload/TriliumNextNotes-Server-${{ github.ref_name }}-${{ inputs.os }}-${{ inputs.arch }}.tar.xz"


### PR DESCRIPTION
Hi,

this PR adapts the file name of the server builds to be the same "scheme" as the Desktop builds

Electron/Desktop
```
TriliumNextNotes-${{ github.ref_name }}-${{ inputs.os }}-${{ inputs.arch }}.$ext
```

Server:
```
TriliumNextNotes-Server-${{ github.ref_name }}-${{ inputs.os }}-${{ inputs.arch }}.tar.xz
```

I opted to put the "Server" part right after the project name, to make it *easily* distinguishable.
(edit: I capitalized it, because I think we could think about "branding" the server part as separate "package" at some point:
`TriliumNext Notes` as the "main application" for the Desktop vs `TriliumNext Notes Server` making it clear this is more for the "self-hosted" people.  This would be in a similar fashion to `VS Code` and `VS Code Server` or `Joplin` and `Joplin Server`). But tht discussion will be a separate topic altogether and will naturally come, when we pursue the "split codebase and mono-repo" path at some point :-))

That should then translate to package names like:

TriliumNextNotes-Server-v0.95.7-linux-x64.tar.xz
TriliumNextNotes-v0.95.7-linux-x64.tar.xz


edit:

this closes TriliumNext/trilium#5448
