### PR TITLE
Fix pressing enter to submit for "Add Link"- and "Include Note"-Dialogs

### DIFF
--- a/src/public/app/widgets/dialogs/add_link.js
+++ b/src/public/app/widgets/dialogs/add_link.js
@@ -41,14 +41,14 @@ const TPL = `
                             <br/>
                             <label>
                                 ${t("add_link.link_title")}
-                                
+
                                 <input class="link-title form-control" style="width: 100%;">
                             </label>
                         </div>
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary">${t("add_link.button_add_link")}</button>
+                    <button type="submit" class="add-link-submit btn btn-primary">${t("add_link.button_add_link")}</button>
                 </div>
             </form>
         </div>
@@ -64,6 +64,7 @@ export default class AddLinkDialog extends BasicWidget {
         this.$addLinkTitleSettings = this.$widget.find(".add-link-title-settings");
         this.$addLinkTitleRadios = this.$widget.find(".add-link-title-radios");
         this.$addLinkTitleFormGroup = this.$widget.find(".add-link-title-form-group");
+        this.$submitButton = this.$widget.find(".add-link-submit")
 
         /** @var TextTypeWidget */
         this.textTypeWidget = null;
@@ -84,6 +85,9 @@ export default class AddLinkDialog extends BasicWidget {
             }
 
             return false;
+        });
+         this.$autoComplete.on("autocomplete:selected", () => {
+            this.$submitButton.trigger("focus");
         });
     }
 

--- a/src/public/app/widgets/dialogs/include_note.js
+++ b/src/public/app/widgets/dialogs/include_note.js
@@ -44,7 +44,7 @@ const TPL = `
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary">${t("include_note.button_include")}</button>
+                    <button type="submit" class="include-note-submit btn btn-primary">${t("include_note.button_include")}</button>
                 </div>
             </form>
         </div>
@@ -57,6 +57,7 @@ export default class IncludeNoteDialog extends BasicWidget {
         this.modal = bootstrap.Modal.getOrCreateInstance(this.$widget);
         this.$form = this.$widget.find(".include-note-form");
         this.$autoComplete = this.$widget.find(".include-note-autocomplete");
+        this.$submitButton = this.$widget.find(".include-note-submit")
         this.$form.on("submit", () => {
             const notePath = this.$autoComplete.getSelectedNotePath();
 
@@ -68,6 +69,9 @@ export default class IncludeNoteDialog extends BasicWidget {
             }
 
             return false;
+        });
+        this.$autoComplete.on("autocomplete:selected", () => {
+            this.$submitButton.trigger("focus");
         });
     }
 


### PR DESCRIPTION
This PR fixes the issue described in #1100 by adding an event listener in both files (add_link.js & include_note.js) which shifts focus to the enter button.