### PR TITLE
Fix the password box not removed after entering protected mode

### DIFF
--- a/src/public/app/widgets/type_widgets/protected_session.js
+++ b/src/public/app/widgets/type_widgets/protected_session.js
@@ -48,4 +48,8 @@ export default class ProtectedSessionTypeWidget extends TypeWidget {
 
         super.doRender();
     }
+
+    async doRefresh(note) {
+        // do nothing
+    }
 }


### PR DESCRIPTION
Implementing `doRefresh(.)` for `ProtectedSessionTypeWidget` fixes the issue mentioned in TriliumNext/trilium#5441.

Maybe a default implementation for `doRefresh(.)` in `TypeWidget` would be better?