### PR TITLE
fix(import/mime): fix ts file mime import handling

### DIFF
--- a/src/services/import/mime.spec.ts
+++ b/src/services/import/mime.spec.ts
@@ -12,12 +12,17 @@ describe("#getMime", () => {
         ],
 
         [
-            "File extension that is defined in EXTENSION_TO_MIME",
+            "File extension ('.py')  that is defined in EXTENSION_TO_MIME",
             ["test.py"], "text/x-python"
         ],
 
         [
-            "File extension with inconsisten capitalization that is defined in EXTENSION_TO_MIME",
+            "File extension ('.ts') that is defined in EXTENSION_TO_MIME",
+            ["test.ts"], "text/x-typescript"
+        ],
+
+        [
+            "File extension with inconsistent capitalization that is defined in EXTENSION_TO_MIME",
             ["test.gRoOvY"], "text/x-groovy"
         ],
 

--- a/src/services/import/mime.ts
+++ b/src/services/import/mime.ts
@@ -37,6 +37,7 @@ const CODE_MIME_TYPES = new Set([
     "text/x-sql",
     "text/x-stex",
     "text/x-swift",
+    "text/x-typescript",
     "text/x-yaml"
 ]);
 
@@ -65,7 +66,8 @@ const EXTENSION_TO_MIME = new Map<string, string>([
     [".py", "text/x-python"],
     [".rb", "text/x-ruby"],
     [".scala", "text/x-scala"],
-    [".swift", "text/x-swift"]
+    [".swift", "text/x-swift"],
+    [".ts", "text/x-typescript"]
 ]);
 
 /** @returns false if MIME is not detected */


### PR DESCRIPTION
Hi,

this PR adds some tiny extra handling for ".ts" file which in 2025 are more likely to be TypeScript rather than some older video format.

fixes #1142 