### PR TITLE
feat: allow setting custom cookiePath

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -28,6 +28,15 @@ keyPath=
 # expressjs shortcuts are supported: loopback(127.0.0.1/8, ::1/128), linklocal(169.254.0.0/16, fe80::/10), uniquelocal(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7)
 trustedReverseProxy=false
 
+
+[Cookies]
+# Use this setting to constrain the current instance's "Path" value for the set cookies
+# This can be useful, when you have several instances running on the same domain, under different paths (e.g. by using a reverse proxy).
+# It prevents your instances from overwriting each others' cookies.
+# e.g. if you have https://your-domain.com/triliumNext/instanceA and https://your-domain.com/triliumNext/instanceB
+# you would want to set the cookiePath value to "/triliumNext/instanceA" for your first and "/triliumNext/instanceB" for your second instance
+cookiePath=/
+
 [Sync]
 #syncServerHost=
 #syncServerTimeout=

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -29,7 +29,7 @@ keyPath=
 trustedReverseProxy=false
 
 
-[Cookies]
+[Session]
 # Use this setting to constrain the current instance's "Path" value for the set cookies
 # This can be useful, when you have several instances running on the same domain, under different paths (e.g. by using a reverse proxy).
 # It prevents your instances from overwriting each others' cookies.

--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -1,11 +1,12 @@
 import { doubleCsrf } from "csrf-csrf";
 import sessionSecret from "../services/session_secret.js";
 import { isElectron } from "../services/utils.js";
+import config from "../services/config.js";
 
 const doubleCsrfUtilities = doubleCsrf({
     getSecret: () => sessionSecret,
     cookieOptions: {
-        path: "", // empty, so cookie is valid only for the current path
+        path: config.Cookies.cookiePath,
         secure: false,
         sameSite: "strict",
         httpOnly: !isElectron // set to false for Electron, see https://github.com/TriliumNext/Notes/pull/966

--- a/src/routes/csrf_protection.ts
+++ b/src/routes/csrf_protection.ts
@@ -6,7 +6,7 @@ import config from "../services/config.js";
 const doubleCsrfUtilities = doubleCsrf({
     getSecret: () => sessionSecret,
     cookieOptions: {
-        path: config.Cookies.cookiePath,
+        path: config.Session.cookiePath,
         secure: false,
         sameSite: "strict",
         httpOnly: !isElectron // set to false for Electron, see https://github.com/TriliumNext/Notes/pull/966

--- a/src/routes/session_parser.ts
+++ b/src/routes/session_parser.ts
@@ -2,6 +2,7 @@ import session from "express-session";
 import sessionFileStore from "session-file-store";
 import sessionSecret from "../services/session_secret.js";
 import dataDir from "../services/data_dir.js";
+import config from "../services/config.js";
 const FileStore = sessionFileStore(session);
 
 const sessionParser = session({
@@ -9,7 +10,7 @@ const sessionParser = session({
     resave: false, // true forces the session to be saved back to the session store, even if the session was never modified during the request.
     saveUninitialized: false, // true forces a session that is "uninitialized" to be saved to the store. A session is uninitialized when it is new but not modified.
     cookie: {
-        //    path: "/",
+        path: config.Cookies.cookiePath,
         httpOnly: true,
         maxAge: 24 * 60 * 60 * 1000 // in milliseconds
     },

--- a/src/routes/session_parser.ts
+++ b/src/routes/session_parser.ts
@@ -10,7 +10,7 @@ const sessionParser = session({
     resave: false, // true forces the session to be saved back to the session store, even if the session was never modified during the request.
     saveUninitialized: false, // true forces a session that is "uninitialized" to be saved to the store. A session is uninitialized when it is new but not modified.
     cookie: {
-        path: config.Cookies.cookiePath,
+        path: config.Session.cookiePath,
         httpOnly: true,
         maxAge: 24 * 60 * 60 * 1000 // in milliseconds
     },

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -32,6 +32,9 @@ export interface TriliumConfig {
         keyPath: string;
         trustedReverseProxy: boolean | string;
     };
+    Cookies: {
+        cookiePath: string;
+    }
     Sync: {
         syncServerHost: string;
         syncServerTimeout: string;
@@ -74,6 +77,11 @@ const config: TriliumConfig = {
 
         trustedReverseProxy:
             process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy || false
+    },
+
+    Cookies: {
+        cookiePath:
+            process.env.TRILIUM_COOKIES_COOKIEPATH || iniConfig?.Cookies?.cookiePath || "/"
     },
 
     Sync: {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -32,7 +32,7 @@ export interface TriliumConfig {
         keyPath: string;
         trustedReverseProxy: boolean | string;
     };
-    Cookies: {
+    Session: {
         cookiePath: string;
     }
     Sync: {
@@ -79,9 +79,9 @@ const config: TriliumConfig = {
             process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy || false
     },
 
-    Cookies: {
+    Session: {
         cookiePath:
-            process.env.TRILIUM_COOKIES_COOKIEPATH || iniConfig?.Cookies?.cookiePath || "/"
+            process.env.TRILIUM_SESSION_COOKIEPATH || iniConfig?.Session?.cookiePath || "/"
     },
 
     Sync: {


### PR DESCRIPTION
Hi,

this PR will allow users to set a custom cookiePath, if they require it (see TriliumNext/trilium#5473 and the comment in the config-sample.ini for further info on why this might be needed).

I've added a new "Cookies" section, because goal is to also allow e.g. the user to set a custom cookie expiration time, which will be a separate PR, but will go into the same config section.

closes TriliumNext/trilium#5473 

(still in draft, as I need to do a tiny test with the CSRF cookie as well, and requests to the API as well)


*edit*: ~There also seems to be an issue with completely new instances, where there is no existing cookie set yet – it currently crashes, because it seems the req.session prop is undefined, when setting the path to anything other than "" or "/"~
*edit2*: ignore the above edit, that was partially a stupid mistake on end running my local dev instance  :-)