### PR TITLE
feat: allow setting custom session cookie expiration

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -36,6 +36,7 @@ trustedReverseProxy=false
 # e.g. if you have https://your-domain.com/triliumNext/instanceA and https://your-domain.com/triliumNext/instanceB
 # you would want to set the cookiePath value to "/triliumNext/instanceA" for your first and "/triliumNext/instanceB" for your second instance
 cookiePath=/
+cookieMaxAge=
 
 [Sync]
 #syncServerHost=

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -30,13 +30,18 @@ trustedReverseProxy=false
 
 
 [Session]
-# Use this setting to constrain the current instance's "Path" value for the set cookies
+# Use this setting to set a custom value for the "Path" Attribute value of the session cookie.
 # This can be useful, when you have several instances running on the same domain, under different paths (e.g. by using a reverse proxy).
-# It prevents your instances from overwriting each others' cookies.
-# e.g. if you have https://your-domain.com/triliumNext/instanceA and https://your-domain.com/triliumNext/instanceB
+# It prevents your instances from overwriting each others' cookies, allowing you to stay logged in multiple instances simultanteously.
+# E.g. if you have instances running under https://your-domain.com/triliumNext/instanceA and https://your-domain.com/triliumNext/instanceB
 # you would want to set the cookiePath value to "/triliumNext/instanceA" for your first and "/triliumNext/instanceB" for your second instance
 cookiePath=/
-cookieMaxAge=
+
+# Use this setting to set a custom value for the "Max-Age" Attribute of the session cookie.
+# This controls how long your session will be valid, before it expires and you need to log in again, when you use the "Remember Me" option.
+# Value needs to be entered in Seconds.
+# Default value is 1814400 Seconds, which is 21 Days.
+cookieMaxAge=1814400
 
 [Sync]
 #syncServerHost=

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -80,7 +80,6 @@ function login(req: Request, res: Response) {
 
         res.redirect(".");
     });
-
 }
 
 function verifyPassword(guessedPassword: string) {

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -70,9 +70,12 @@ function login(req: Request, res: Response) {
     }
 
     req.session.regenerate(() => {
-        const sessionMaxAge = 21 * 24 * 3600000 // 3 weeks in Milliseconds
+        if (!rememberMe) {
+            // unset default maxAge set by sessionParser
+            // Cookie becomes non-persistent and expires after current browser session (e.g. when browser is closed)
+            req.session.cookie.maxAge = undefined;
+        }
 
-        req.session.cookie.maxAge = (rememberMe) ? sessionMaxAge : undefined;
         req.session.loggedIn = true;
 
         res.redirect(".");

--- a/src/routes/session_parser.ts
+++ b/src/routes/session_parser.ts
@@ -12,11 +12,11 @@ const sessionParser = session({
     cookie: {
         path: config.Session.cookiePath,
         httpOnly: true,
-        maxAge:  config.Session.cookieMaxAge
+        maxAge:  config.Session.cookieMaxAge * 1000 // needs value in milliseconds
     },
     name: "trilium.sid",
     store: new FileStore({
-        ttl: config.Session.cookieMaxAge / 1000, // needs value in seconds
+        ttl: config.Session.cookieMaxAge,
         path: `${dataDir.TRILIUM_DATA_DIR}/sessions`
     })
 });

--- a/src/routes/session_parser.ts
+++ b/src/routes/session_parser.ts
@@ -12,7 +12,7 @@ const sessionParser = session({
     cookie: {
         path: config.Session.cookiePath,
         httpOnly: true,
-        maxAge:  config.Session.cookieMaxAge * 1000 // needs value in milliseconds
+        maxAge: config.Session.cookieMaxAge * 1000 // needs value in milliseconds
     },
     name: "trilium.sid",
     store: new FileStore({

--- a/src/routes/session_parser.ts
+++ b/src/routes/session_parser.ts
@@ -16,7 +16,7 @@ const sessionParser = session({
     },
     name: "trilium.sid",
     store: new FileStore({
-        ttl: 30 * 24 * 3600,
+        ttl: config.Session.cookieMaxAge / 1000, // needs value in seconds
         path: `${dataDir.TRILIUM_DATA_DIR}/sessions`
     })
 });

--- a/src/routes/session_parser.ts
+++ b/src/routes/session_parser.ts
@@ -12,7 +12,7 @@ const sessionParser = session({
     cookie: {
         path: config.Session.cookiePath,
         httpOnly: true,
-        maxAge: 24 * 60 * 60 * 1000 // in milliseconds
+        maxAge:  config.Session.cookieMaxAge
     },
     name: "trilium.sid",
     store: new FileStore({

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -85,7 +85,7 @@ const config: TriliumConfig = {
             process.env.TRILIUM_SESSION_COOKIEPATH || iniConfig?.Session?.cookiePath || "/",
 
         cookieMaxAge:
-            process.env.TRILIUM_SESSION_COOKIEMAXAGE || iniConfig?.Session?.cookieMaxAge || "24 * 60 * 60 * 1000" // 24 hours in Milliseconds
+            process.env.TRILIUM_SESSION_COOKIEMAXAGE || iniConfig?.Session?.cookieMaxAge || 21 * 24 * 60 * 60 // 21 Days in Seconds
     },
 
     Sync: {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -85,7 +85,7 @@ const config: TriliumConfig = {
             process.env.TRILIUM_SESSION_COOKIEPATH || iniConfig?.Session?.cookiePath || "/",
 
         cookieMaxAge:
-            process.env.TRILIUM_SESSION_COOKIEMAXAGE || iniConfig?.Session?.cookieMaxAge || 21 * 24 * 60 * 60 // 21 Days in Seconds
+            parseInt(String(process.env.TRILIUM_SESSION_COOKIEMAXAGE)) || parseInt(iniConfig?.Session?.cookieMaxAge) || 21 * 24 * 60 * 60 // 21 Days in Seconds
     },
 
     Sync: {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -34,6 +34,7 @@ export interface TriliumConfig {
     };
     Session: {
         cookiePath: string;
+        cookieMaxAge: number;
     }
     Sync: {
         syncServerHost: string;
@@ -81,7 +82,10 @@ const config: TriliumConfig = {
 
     Session: {
         cookiePath:
-            process.env.TRILIUM_SESSION_COOKIEPATH || iniConfig?.Session?.cookiePath || "/"
+            process.env.TRILIUM_SESSION_COOKIEPATH || iniConfig?.Session?.cookiePath || "/",
+
+        cookieMaxAge:
+            process.env.TRILIUM_SESSION_COOKIEMAXAGE || iniConfig?.Session?.cookieMaxAge || "24 * 60 * 60 * 1000" // 24 hours in Milliseconds
     },
 
     Sync: {


### PR DESCRIPTION
Hi,

this PR is a feature on top of #1155 – which is why you see some extra commits here.

It will allow users to set their own session expiration, e.g. currently it defaults to 1 day – but I can see users who might want to limit it to a shorter period of time (myself included ;-)).

it also set the TTL of the FileStore for the session to the same value as the maxAge from the cookie.
Before that it was set to 30 days, which (if I am not completely mistaken) would've left a couple of dead "unused" session in the FileStore.

~(this still needs some testing "in the field", which is why it is set to draft)~