### PR TITLE
fix(ui): disallow text selection in dropdown-menus

### DIFF
--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -294,6 +294,8 @@ button kbd {
     color: var(--menu-text-color) !important;
     font-size: inherit;
     background-color: var(--menu-background-color) !important;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 body.desktop .dropdown-menu {


### PR DESCRIPTION
Hi,

this PR fixes some weird behaviour in dropdown menus:
 Currently you were able to select text, by holding the left mouse button and dragging the mouse across the screen, while inside the dropdown menu.