### PR TITLE
build: fix missing copying of etapi.openapi.yaml in build process

### DIFF
--- a/bin/copy-dist.ts
+++ b/bin/copy-dist.ts
@@ -29,7 +29,7 @@ const copy = async () => {
         fs.copySync(path.join("build", srcFile), destFile, { recursive: true });
     }
 
-    const filesToCopy = ["config-sample.ini", "tsconfig.webpack.json"];
+    const filesToCopy = ["config-sample.ini", "tsconfig.webpack.json", "./src/etapi/etapi.openapi.yaml"];
     for (const file of filesToCopy) {
         log(`Copying ${file}`);
         await fs.copy(file, path.join(DEST_DIR, file));


### PR DESCRIPTION
this fixes TriliumNext/trilium#5462 

~(still in draft: need to double check, if the Docker ~and Server~ build also need adjusting)~

I've checked Docker and Server builds as well, and they seem to include the file correctly.

e.g. 
Docker (using the "develop" tag):

![grafik](https://github.com/user-attachments/assets/6ce357dc-840e-4d4e-9f60-4a7643195778)


and building the Server version using the `build-server` script:

![grafik](https://github.com/user-attachments/assets/fe0a9ab9-6b3e-46ac-8fe4-0256904bf8a6)
