### PR TITLE
Allow removing weak branches even if it's hoisted

### DIFF
--- a/src/becca/entities/bbranch.ts
+++ b/src/becca/entities/bbranch.ts
@@ -159,7 +159,7 @@ class BBranch extends AbstractBeccaEntity<BBranch> {
             }
         }
 
-        if (this.noteId === "root" || this.noteId === cls.getHoistedNoteId()) {
+        if ((this.noteId === "root" || this.noteId === cls.getHoistedNoteId()) && !this.isWeak) {
             throw new Error("Can't delete root or hoisted branch/note");
         }
 


### PR DESCRIPTION
Mainly to allow unsharing hoisted notes. Closes #518 and #707.