### PR TITLE
chore(copy-dist): "unpack" log messages before printing

### DIFF
--- a/bin/copy-dist.ts
+++ b/bin/copy-dist.ts
@@ -7,9 +7,9 @@ const DEST_DIR_NODE_MODULES = path.join(DEST_DIR, "node_modules");
 
 const VERBOSE = process.env.VERBOSE;
 
-function log(...args) {
+function log(...args: any[]) {
     if (VERBOSE) {
-        console.log(args);
+        console.log(...args);
     }
 }
 


### PR DESCRIPTION
Hi,

this PR "unpacks" the messages before passing them on to console.log.

Previously it was printing all messages as part of an array, which was unnecessarily ugly/hard to read  i.e. 
```
["message A1"]
["message B1", "message B2"]
```

After spreading the array, we get the actual intended/desired output of
```
message A1
message B1 message B2
```