### PR TITLE
Bare2share - Redirect bare domain to defined #shareRoot

### DIFF
--- a/src/public/app/widgets/type_widgets/content_widget.ts
+++ b/src/public/app/widgets/type_widgets/content_widget.ts
@@ -35,7 +35,7 @@ import RibbonOptions from "./options/appearance/ribbon.js";
 import LocalizationOptions from "./options/appearance/i18n.js";
 import CodeBlockOptions from "./options/appearance/code_block.js";
 import EditorOptions from "./options/text_notes/editor.js";
-import ShareSettingsOptions from "./options/other/share_settings.js"; // added import statement
+import ShareSettingsOptions from "./options/other/share_settings.js";
 import type FNote from "../../entities/fnote.js";
 import type NoteContextAwareWidget from "../note_context_aware_widget.js";
 

--- a/src/public/app/widgets/type_widgets/content_widget.ts
+++ b/src/public/app/widgets/type_widgets/content_widget.ts
@@ -35,6 +35,7 @@ import RibbonOptions from "./options/appearance/ribbon.js";
 import LocalizationOptions from "./options/appearance/i18n.js";
 import CodeBlockOptions from "./options/appearance/code_block.js";
 import EditorOptions from "./options/text_notes/editor.js";
+import ShareSettingsOptions from "./options/other/share_settings.js"; // added import statement
 import type FNote from "../../entities/fnote.js";
 import type NoteContextAwareWidget from "../note_context_aware_widget.js";
 
@@ -76,7 +77,8 @@ const CONTENT_WIDGETS: Record<string, (typeof NoteContextAwareWidget)[]> = {
         RevisionsSnapshotIntervalOptions,
         RevisionSnapshotsLimitOptions,
         NetworkConnectionsOptions,
-        HtmlImportTagsOptions
+        HtmlImportTagsOptions,
+        ShareSettingsOptions // moved to the end of the array
     ],
     _optionsAdvanced: [DatabaseIntegrityCheckOptions, DatabaseAnonymizationOptions, AdvancedSyncOptions, VacuumDatabaseOptions],
     _backendLog: [BackendLogWidget]

--- a/src/public/app/widgets/type_widgets/options/other/share_settings.ts
+++ b/src/public/app/widgets/type_widgets/options/other/share_settings.ts
@@ -1,6 +1,7 @@
 import OptionsWidget from "../options_widget.js";
 import options from "../../../../services/options.js";
 import { t } from "../../../../services/i18n.js";
+import type { OptionMap, OptionNames } from "../../../../../../services/options_interface.js";
 
 const TPL = `
 <div class="card-body">
@@ -27,9 +28,12 @@ export default class ShareSettingsOptions extends OptionsWidget {
     doRender() {
         this.$widget = $(TPL);
         this.contentSized();
+
+        // Add change handlers for both checkboxes
+        this.$widget.find('input[type="checkbox"]').on('change', () => this.save());
     }
 
-    async optionsLoaded(options: Record<string, any>) {
+    async optionsLoaded(options: OptionMap) {
         this.$widget.find('input[name="redirectBareDomain"]').prop('checked', 
             options.redirectBareDomain === 'true');
             
@@ -39,9 +43,9 @@ export default class ShareSettingsOptions extends OptionsWidget {
 
     async save() {
         const redirectBareDomain = this.$widget.find('input[name="redirectBareDomain"]').prop('checked');
-        await this.updateOption('redirectBareDomain', redirectBareDomain.toString());
+        await this.updateOption<'redirectBareDomain'>('redirectBareDomain', redirectBareDomain.toString());
 
         const showLoginInShareTheme = this.$widget.find('input[name="showLoginInShareTheme"]').prop('checked');
-        await this.updateOption('showLoginInShareTheme', showLoginInShareTheme.toString());
+        await this.updateOption<'showLoginInShareTheme'>('showLoginInShareTheme', showLoginInShareTheme.toString());
     }
 }

--- a/src/public/app/widgets/type_widgets/options/other/share_settings.ts
+++ b/src/public/app/widgets/type_widgets/options/other/share_settings.ts
@@ -1,0 +1,47 @@
+import OptionsWidget from "../options_widget.js";
+import options from "../../../../services/options.js";
+import { t } from "../../../../services/i18n.js";
+
+const TPL = `
+<div class="card-body">
+    <h4>${t('Share Settings')}</h4>
+    
+    <div class="form-check">
+        <label class="form-check-label">
+            <input class="form-check-input" type="checkbox" name="redirectBareDomain" value="true">
+            ${t('Redirect bare domain to Share page')}
+        </label>
+        <p class="form-text">${t('When enabled, accessing the root URL will redirect to the Share page instead of Login')}</p>
+    </div>
+
+    <div class="form-check">
+        <label class="form-check-label">
+            <input class="form-check-input" type="checkbox" name="showLoginInShareTheme" value="true">
+            ${t('Show Login link in Share theme')}
+        </label>
+        <p class="form-text">${t('Add a login link to the Share page footer')}</p>
+    </div>
+</div>`;
+
+export default class ShareSettingsOptions extends OptionsWidget {
+    doRender() {
+        this.$widget = $(TPL);
+        this.contentSized();
+    }
+
+    async optionsLoaded(options: Record<string, any>) {
+        this.$widget.find('input[name="redirectBareDomain"]').prop('checked', 
+            options.redirectBareDomain === 'true');
+            
+        this.$widget.find('input[name="showLoginInShareTheme"]').prop('checked',
+            options.showLoginInShareTheme === 'true');
+    }
+
+    async save() {
+        const redirectBareDomain = this.$widget.find('input[name="redirectBareDomain"]').prop('checked');
+        await this.updateOption('redirectBareDomain', redirectBareDomain.toString());
+
+        const showLoginInShareTheme = this.$widget.find('input[name="showLoginInShareTheme"]').prop('checked');
+        await this.updateOption('showLoginInShareTheme', showLoginInShareTheme.toString());
+    }
+}

--- a/src/routes/api/options.ts
+++ b/src/routes/api/options.ts
@@ -72,7 +72,9 @@ const ALLOWED_OPTIONS = new Set([
     "textNoteEditorMultilineToolbar",
     "layoutOrientation",
     "backgroundEffects",
-    "allowedHtmlTags" // Allow configuring HTML import tags
+    "allowedHtmlTags",
+    "redirectBareDomain",
+    "showLoginInShareTheme"
 ]);
 
 function getOptions() {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -7,6 +7,7 @@ import { isElectron } from "./utils.js";
 import passwordEncryptionService from "./encryption/password_encryption.js";
 import config from "./config.js";
 import passwordService from "./encryption/password.js";
+import options from "./options.js";
 import type { NextFunction, Request, Response } from "express";
 
 const noAuthentication = config.General && config.General.noAuthentication === true;
@@ -15,7 +16,8 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
     if (!sqlInit.isDbInitialized()) {
         res.redirect("setup");
     } else if (!req.session.loggedIn && !isElectron && !noAuthentication) {
-        res.redirect("share");
+        const redirectToShare = options.getOption('redirectBareDomain') === 'true';
+        res.redirect(redirectToShare ? "share" : "login");
     } else {
         next();
     }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -15,7 +15,7 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
     if (!sqlInit.isDbInitialized()) {
         res.redirect("setup");
     } else if (!req.session.loggedIn && !isElectron && !noAuthentication) {
-        res.redirect("login");
+        res.redirect("share");
     } else {
         next();
     }

--- a/src/services/options_init.ts
+++ b/src/services/options_init.ts
@@ -252,7 +252,11 @@ const defaultOptions: DefaultOption[] = [
             "tt"
         ]),
         isSynced: true
-    }
+    },
+
+    // Share settings
+    { name: 'redirectBareDomain', value: 'false', isSynced: true },
+    { name: 'showLoginInShareTheme', value: 'false', isSynced: true }
 ];
 
 /**

--- a/src/services/options_interface.ts
+++ b/src/services/options_interface.ts
@@ -29,6 +29,9 @@ export interface OptionDefinitions extends KeyboardShortcutsOptions<KeyboardActi
     detailFontFamily: FontFamily;
     monospaceFontFamily: FontFamily;
     spellCheckLanguageCode: string;
+    // Share settings
+    redirectBareDomain: string;
+    showLoginInShareTheme: string;
     codeNotesMimeTypes: string;
     headingStyle: string;
     highlightsList: string;

--- a/src/share/routes.ts
+++ b/src/share/routes.ts
@@ -16,6 +16,7 @@ import type SNote from "./shaca/entities/snote.js";
 import type SBranch from "./shaca/entities/sbranch.js";
 import type SAttachment from "./shaca/entities/sattachment.js";
 import utils from "../services/utils.js";
+import optionService from '../services/option_service.js';
 
 function getSharedSubTreeRoot(note: SNote): { note?: SNote; branch?: SBranch } {
     if (note.noteId === shareRoot.SHARE_ROOT_NOTE_ID) {
@@ -151,7 +152,8 @@ function register(router: Router) {
 
         const { header, content, isEmpty } = contentRenderer.getContent(note);
         const subRoot = getSharedSubTreeRoot(note);
-        const opts = { note, header, content, isEmpty, subRoot, assetPath, appPath };
+        const showLoginInShareTheme = optionService.getOption('showLoginInShareTheme');
+        const opts = { note, header, content, isEmpty, subRoot, assetPath, appPath, showLoginInShareTheme };
         let useDefaultView = true;
 
         // Check if the user has their own template

--- a/src/share/routes.ts
+++ b/src/share/routes.ts
@@ -16,7 +16,7 @@ import type SNote from "./shaca/entities/snote.js";
 import type SBranch from "./shaca/entities/sbranch.js";
 import type SAttachment from "./shaca/entities/sattachment.js";
 import utils from "../services/utils.js";
-import optionService from '../services/option_service.js';
+import options from '../services/options.js';
 
 function getSharedSubTreeRoot(note: SNote): { note?: SNote; branch?: SBranch } {
     if (note.noteId === shareRoot.SHARE_ROOT_NOTE_ID) {
@@ -152,7 +152,7 @@ function register(router: Router) {
 
         const { header, content, isEmpty } = contentRenderer.getContent(note);
         const subRoot = getSharedSubTreeRoot(note);
-        const showLoginInShareTheme = optionService.getOption('showLoginInShareTheme');
+        const showLoginInShareTheme = options.getOption('showLoginInShareTheme');
         const opts = { note, header, content, isEmpty, subRoot, assetPath, appPath, showLoginInShareTheme };
         let useDefaultView = true;
 

--- a/src/views/share/page.ejs
+++ b/src/views/share/page.ejs
@@ -88,5 +88,10 @@
         </nav>
     <% } %>
 </div>
+<footer>
+    <% if (showLoginInShareTheme === 'true') { %>
+        <p><a href="/login" class="login-link">Login</a></p>
+    <% } %>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
Addresses https://github.com/TriliumNext/Notes/issues/658
Adds _Options >> Other >> Share Settings_:

- Adds a checkbox to enable/disable bare domain redirect to /share
- "Show login in share theme" option

Requires a note that is a) shared, and b) defined as `#shareRoot`

![image](https://github.com/user-attachments/assets/91e1789a-945a-4a80-b65c-a256c2238a28)
