### PR TITLE
feat(options_init): add typescript as default set codeNotesMimeTypes value

### DIFF
--- a/src/services/options_init.ts
+++ b/src/services/options_init.ts
@@ -98,7 +98,7 @@ const defaultOptions: DefaultOption[] = [
     { name: "codeLineWrapEnabled", value: "true", isSynced: false },
     {
         name: "codeNotesMimeTypes",
-        value: '["text/x-csrc","text/x-c++src","text/x-csharp","text/css","text/x-go","text/x-groovy","text/x-haskell","text/html","message/http","text/x-java","application/javascript;env=frontend","application/javascript;env=backend","application/json","text/x-kotlin","text/x-markdown","text/x-perl","text/x-php","text/x-python","text/x-ruby",null,"text/x-sql","text/x-sqlite;schema=trilium","text/x-swift","text/xml","text/x-yaml","text/x-sh"]',
+        value: '["text/x-csrc","text/x-c++src","text/x-csharp","text/css","text/x-go","text/x-groovy","text/x-haskell","text/html","message/http","text/x-java","application/javascript;env=frontend","application/javascript;env=backend","application/json","text/x-kotlin","text/x-markdown","text/x-perl","text/x-php","text/x-python","text/x-ruby",null,"text/x-sql","text/x-sqlite;schema=trilium","text/x-swift","text/xml","text/x-yaml","text/x-sh","application/typescript"]',
         isSynced: true
     },
     { name: "leftPaneWidth", value: "25", isSynced: false },


### PR DESCRIPTION
since it is a very widespread/popular language, it makes sense to have it on by default :-)

closes #1219