### PR TITLE
fix(ci): add missing windows zip build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             extension: [deb, rpm, zip, flatpak]
           - name: windows
             image: windows-latest
-            extension: exe
+            extension: [exe, zip]
     runs-on: ${{ matrix.os.image }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
apply same fix as https://github.com/TriliumNext/Notes/commit/558bee72e929afe6f7471d7557d76a4898d5a18f on release workflow

(I thought there would be an additional issue with the action.yml – because in the old action.yml there was some windows specific Powershell code to rename the files. This isn't here anymore and I thought that would be causing the files to be missing, but it looks like that is not really the case – otherwise the previously fixed nightly workflow would still be missing the files as well).

