### PR TITLE
ci: remove unneeded extra arm64 handling

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -27,10 +27,6 @@ runs:
     - name: Install dependencies
       shell: bash
       run: npm ci
-    - name: Temporary Flatpak arm64 workaround till https://github.com/electron/forge/pull/3839 is merged
-      if: ${{ inputs.os == 'linux' && inputs.arch == 'arm64' }}
-      shell: bash
-      run:  sed -e "s/case 'armv7l'/case 'arm64'/g" -e "s/return 'arm'/return 'aarch64'/g" -i node_modules/@electron-forge/maker-flatpak/dist/MakerFlatpak.js
     - name: Update build info
       shell: bash
       run: npm run chore:update-build-info

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "The architecture to build for: x64, arm64"
     required: true
   extension:
-    description: "Platform specific extensions to copy in the output: dmg, deb, rpm, exe"
+    description: "Platform specific extensions to copy in the output: dmg, deb, rpm, exe, zip"
     required: true
 runs:
   using: composite


### PR DESCRIPTION
Hi,

this removes the now unneeded arm64 workaround

the change is now part of electron-forge 7.7.0 which we depend on since
https://github.com/TriliumNext/Notes/commit/fa05f15753fcbfb38129cb9792a063093798d80b


test build on my fork works fine as well:
https://github.com/pano9000/TriliumNextNotes/actions/runs/13472666704/job/37648069341