### PR TITLE
fix/i18n: tiny zen mode UI fixes

### DIFF
--- a/src/public/app/widgets/buttons/global_menu.ts
+++ b/src/public/app/widgets/buttons/global_menu.ts
@@ -137,6 +137,7 @@ const TPL = `
         <li class="dropdown-item" data-trigger-command="toggleZenMode">
             <span class="bx bxs-yin-yang"></span>
             ${t("global_menu.toggle-zen-mode")}
+            <kbd data-command="toggleZenMode"></kbd>
         </li>
 
         <div class="dropdown-divider"></div>

--- a/src/public/app/widgets/close_zen_button.ts
+++ b/src/public/app/widgets/close_zen_button.ts
@@ -1,9 +1,12 @@
 import BasicWidget from "./basic_widget.js";
+import { t } from "../services/i18n.js";
 
 const TPL = `\
 <div class="close-zen-container">
     <button class="button-widget bx icon-action bxs-yin-yang"
-        data-trigger-command="toggleZenMode" />
+        data-trigger-command="toggleZenMode"
+        title="${t("zen_mode.button_exit")}"
+    />
 
     <style>
     :root {

--- a/src/public/translations/en/translation.json
+++ b/src/public/translations/en/translation.json
@@ -645,6 +645,9 @@
     "show-cheatsheet": "Show Cheatsheet",
     "toggle-zen-mode": "Zen Mode"
   },
+  "zen_mode": {
+    "button_exit": "Exit Zen Mode"
+  },
   "sync_status": {
     "unknown": "<p>Sync status will be known once the next sync attempt starts.</p><p>Click to trigger sync now.</p>",
     "connected_with_changes": "<p>Connected to the sync server. <br>There are some outstanding changes yet to be synced.</p><p>Click to trigger sync.</p>",


### PR DESCRIPTION
Hi,

this PR fixes two tiny UI issues with the Zen Mode buttons:

a) it now displays the `<kbd>` shortcut in the global menu
b) it adds a short title message to the button element