### PR TITLE
build(webpack): fix missing type declarations

### DIFF
--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -16,6 +16,7 @@
   "include": ["./src/public/app/**/*"],
   "files": [
     "./src/public/app/types.d.ts",
-    "./src/public/app/types-lib.d.ts"
+    "./src/public/app/types-lib.d.ts",
+    "./src/types.d.ts"
   ]
 }


### PR DESCRIPTION
Hi,

This fixes the currently broken webpack build, which (on my end) is throwing the following errors due to missing types:

```
ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/utils.ts
7:21-31
[tsl] ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/utils.ts(7,22)
      TS7016: Could not find a declaration file for module 'unescape'. '/home/pano/Programming/0_repos/TriliumNextNotes/node_modules/unescape/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/unescape` if it exists or add a new declaration (.d.ts) file containing `declare module 'unescape';`

ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/notes.ts
25:27-43
[tsl] ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/notes.ts(25,28)
      TS7016: Could not find a declaration file for module 'html2plaintext'. '/home/pano/Programming/0_repos/TriliumNextNotes/node_modules/html2plaintext/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/html2plaintext` if it exists or add a new declaration (.d.ts) file containing `declare module 'html2plaintext';`

ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/image.ts
13:23-36
[tsl] ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/image.ts(13,24)
      TS7016: Could not find a declaration file for module 'is-animated'. '/home/pano/Programming/0_repos/TriliumNextNotes/node_modules/is-animated/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/is-animated` if it exists or add a new declaration (.d.ts) file containing `declare module 'is-animated';`

ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/search/services/search.ts
3:28-47
[tsl] ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/search/services/search.ts(3,29)
      TS7016: Could not find a declaration file for module 'normalize-strings'. '/home/pano/Programming/0_repos/TriliumNextNotes/node_modules/normalize-strings/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/normalize-strings` if it exists or add a new declaration (.d.ts) file containing `declare module 'normalize-strings';`

ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/export/md.ts
4:30-59
[tsl] ERROR in /home/pano/Programming/0_repos/TriliumNextNotes/src/services/export/md.ts(4,31)
      TS7016: Could not find a declaration file for module '@joplin/turndown-plugin-gfm'. '/home/pano/Programming/0_repos/TriliumNextNotes/node_modules/@joplin/turndown-plugin-gfm/lib/turndown-plugin-gfm.cjs.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/joplin__turndown-plugin-gfm` if it exists or add a new declaration (.d.ts) file containing `declare module '@joplin/turndown-plugin-gfm';`

5 errors have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
```