### PR TITLE
Pass the required `APPLE` secrets to the `build-electron` action

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -20,8 +20,8 @@ runs:
       if: inputs.os == 'macos'
       uses: apple-actions/import-codesign-certs@v2
       with:
-        p12-file-base64: ${{ env.APPLE_APP_CERTIFICATE_BASE64 }}
-        p12-password: ${{ env.APPLE_APP_CERTIFICATE_PASSWORD }}
+        p12-file-base64: ${{ secrets.APPLE_APP_CERTIFICATE_BASE64 }}
+        p12-password: ${{ secrets.APPLE_APP_CERTIFICATE_PASSWORD }}
         keychain: build
         keychain-password: ${{ github.run_id }}
 
@@ -29,8 +29,8 @@ runs:
       if: inputs.os == 'macos'
       uses: apple-actions/import-codesign-certs@v2
       with:
-        p12-file-base64: ${{ env.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
-        p12-password: ${{ env.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
+        p12-file-base64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
+        p12-password: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
         keychain: build
         keychain-password: ${{ github.run_id }}
         # We don't need to create a keychain here because we're using the build keychain that was created in the previous step
@@ -74,9 +74,9 @@ runs:
       shell: bash
       env:
         # Pass through required environment variables for signing and notarization
-        APPLE_TEAM_ID: ${{ env.APPLE_TEAM_ID }}
-        APPLE_ID: ${{ env.APPLE_ID }}
-        APPLE_ID_PASSWORD: ${{ env.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       run: |
         # Map OS names to Electron Forge platform names
         if [ "${{ inputs.os }}" = "macos" ]; then

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -20,8 +20,8 @@ runs:
       if: inputs.os == 'macos'
       uses: apple-actions/import-codesign-certs@v2
       with:
-        p12-file-base64: ${{ secrets.APPLE_APP_CERTIFICATE_BASE64 }}
-        p12-password: ${{ secrets.APPLE_APP_CERTIFICATE_PASSWORD }}
+        p12-file-base64: ${{ env.APPLE_APP_CERTIFICATE_BASE64 }}
+        p12-password: ${{ env.APPLE_APP_CERTIFICATE_PASSWORD }}
         keychain: build
         keychain-password: ${{ github.run_id }}
 
@@ -29,8 +29,8 @@ runs:
       if: inputs.os == 'macos'
       uses: apple-actions/import-codesign-certs@v2
       with:
-        p12-file-base64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
-        p12-password: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
+        p12-file-base64: ${{ env.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
+        p12-password: ${{ env.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
         keychain: build
         keychain-password: ${{ github.run_id }}
         # We don't need to create a keychain here because we're using the build keychain that was created in the previous step
@@ -74,9 +74,9 @@ runs:
       shell: bash
       env:
         # Pass through required environment variables for signing and notarization
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        APPLE_TEAM_ID: ${{ env.APPLE_TEAM_ID }}
+        APPLE_ID: ${{ env.APPLE_ID }}
+        APPLE_ID_PASSWORD: ${{ env.APPLE_ID_PASSWORD }}
       run: |
         # Map OS names to Electron Forge platform names
         if [ "${{ inputs.os }}" = "macos" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,36 +33,6 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     steps:
       - uses: actions/checkout@v4
-
-      # Set up certificates and keychain for macOS
-      - name: Install Apple Certificates
-        if: matrix.os.name == 'macos'
-        env:
-          APP_CERTIFICATE_BASE64: ${{ secrets.APPLE_APP_CERTIFICATE_BASE64 }}
-          APP_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_APP_CERTIFICATE_PASSWORD }}
-          INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
-          INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ github.run_id }}
-        run: |
-          # Create keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security set-keychain-settings -t 3600 -u build.keychain
-
-          # Import application certificate
-          echo "$APP_CERTIFICATE_BASE64" | base64 --decode > application.p12
-          security import application.p12 -k build.keychain -P "$APP_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          rm application.p12
-
-          # Import installer certificate
-          echo "$INSTALLER_CERTIFICATE_BASE64" | base64 --decode > installer.p12
-          security import installer.p12 -k build.keychain -P "$INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          rm installer.p12
-
-          # Update keychain settings
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
-
       - name: Set up node & dependencies
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,10 @@ jobs:
           arch: ${{ matrix.arch }}
           extension: ${{ matrix.os.extension }}
         env:
+          APPLE_APP_CERTIFICATE_BASE64: ${{ secrets.APPLE_APP_CERTIFICATE_BASE64 }}
+          APPLE_APP_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_APP_CERTIFICATE_PASSWORD }}
+          APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
+          APPLE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 on:
   # This can be used to automatically publish nightlies at UTC nighttime
   schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
+    - cron: "0 2 * * *" # run at 2 AM UTC
   # This can be used to allow manually triggering nightlies from the web interface
   workflow_dispatch:
 env:
@@ -45,6 +45,14 @@ jobs:
           os: ${{ matrix.os.name }}
           arch: ${{ matrix.arch }}
           extension: ${{ join(matrix.os.extension, ' ') }}
+        env:
+          APPLE_APP_CERTIFICATE_BASE64: ${{ secrets.APPLE_APP_CERTIFICATE_BASE64 }}
+          APPLE_APP_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_APP_CERTIFICATE_PASSWORD }}
+          APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
+          APPLE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
       - name: Publish release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Unfortunately, in all our pipelines we have to explicitly provide the following environment variables in the step that runs `build-electron`:
```yaml
        env:
          APPLE_APP_CERTIFICATE_BASE64: ${{ secrets.APPLE_APP_CERTIFICATE_BASE64 }}
          APPLE_APP_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_APP_CERTIFICATE_PASSWORD }}
          APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
          APPLE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
          APPLE_ID: ${{ secrets.APPLE_ID }}
          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
```

This is because the `build-electron` step is a `composite` step, and therefore does not have direct access to the repository's `{{ secrets.value }}` GitHub Action's secrets.