### PR TITLE
build(build-server): stop copying dump-db during build

### DIFF
--- a/bin/build-server.sh
+++ b/bin/build-server.sh
@@ -66,8 +66,6 @@ chmod 755 $PKG_DIR/trilium.sh
 cp bin/tpl/anonymize-database.sql $PKG_DIR/
 
 cp -r translations $PKG_DIR/
-cp -r dump-db $PKG_DIR/
-rm -rf $PKG_DIR/dump-db/node_modules
 
 VERSION=`jq -r ".version" package.json`
 


### PR DESCRIPTION
Hi,

this PR modifies the `build-server.sh` script which is used in the build-server CI action to build the server :-)
It removes the copying of the dump-db tool, which currently is useless in that form since it comes in TS form.

See #1115 for more info as well.

this only fixes it for the server build.
For the docker build #1225  will take care of it
and for Electron-forge build, this will have to be taken care of separately, partially related: #403 