### PR TITLE
feat(calendar) improvements

### DIFF
--- a/src/public/app/widgets/view_widgets/calendar_view.ts
+++ b/src/public/app/widgets/view_widgets/calendar_view.ts
@@ -229,8 +229,13 @@ export default class CalendarView extends ViewMode {
             return;
         }
 
-        attributes.setAttribute(note, "label", "startDate", startDate);
-        attributes.setAttribute(note, "label", "endDate", endDate);
+        // Since they can be customized via calendar:startDate=$foo and calendar:endDate=$bar we need to determine the
+        // attributes to be effectively updated
+        const startAttribute = note.getAttributes("label").filter(attr => attr.name == "calendar:startDate").shift()?.value.replace("#", "")||"startDate"
+        const endAttribute = note.getAttributes("label").filter(attr => attr.name == "calendar:endDate").shift()?.value.replace("#", "")||"endDate"
+
+        attributes.setAttribute(note, "label", startAttribute, startDate);
+        attributes.setAttribute(note, "label", endAttribute, endDate);
     }
 
     onEntitiesReloaded({ loadResults }: EventData<"entitiesReloaded">) {

--- a/src/public/app/widgets/view_widgets/calendar_view.ts
+++ b/src/public/app/widgets/view_widgets/calendar_view.ts
@@ -138,7 +138,7 @@ export default class CalendarView extends ViewMode {
 
                 // Promoted attributes
                 if (promotedAttributes) {
-                    for (const [name, value] of Object.entries(promotedAttributes)) {
+                    for (const [name, value] of promotedAttributes) {
                         html += `\
                         <div class="promoted-attribute">
                             <span class="promoted-attribute-name">${name}</span>: <span class="promoted-attribute-value">${value}</span>
@@ -353,7 +353,7 @@ export default class CalendarView extends ViewMode {
         const events: EventInput[] = [];
 
         const calendarDisplayedAttributes = note.getLabelValue("calendar:displayedAttributes")?.split(",");
-        let displayedAttributesData = null;
+        let displayedAttributesData: Array<[string, string]> | null = null;
         if (calendarDisplayedAttributes) {
             displayedAttributesData = await this.#buildDisplayedAttributes(note, calendarDisplayedAttributes);
         }
@@ -380,11 +380,11 @@ export default class CalendarView extends ViewMode {
 
     static async #buildDisplayedAttributes(note: FNote, calendarDisplayedAttributes: string[]) {
         const filteredDisplayedAttributes = note.getAttributes().filter((attr): boolean => calendarDisplayedAttributes.includes(attr.name))
-        const result: Record<string, string> = {};
+        const result: Array<[string, string]> = [];
 
         for (const attribute of filteredDisplayedAttributes) {
-            if (attribute.type === "label") result[attribute.name] = attribute.value;
-            else result[attribute.name] = (await attribute.getTargetNote())?.title || ""
+            if (attribute.type === "label") result.push([attribute.name, attribute.value]);
+            else result.push([attribute.name, (await attribute.getTargetNote())?.title || ""])
         }
 
         return result;


### PR DESCRIPTION
- rename "promotedAttributes" into "displayedAttributes" and permit non-promoted attributes to be displayed

- make it so that events with customized `calendar:startDate` and `calendar:endDate` can be drag&dropped on the calendar view