### PR TITLE
Fix the bug where note revisions cannot be previewed.

### DIFF
--- a/src/public/app/widgets/dialogs/revisions.ts
+++ b/src/public/app/widgets/dialogs/revisions.ts
@@ -188,6 +188,7 @@ export default class RevisionsDialog extends BasicWidget {
     }
 
     async loadRevisions(noteId: string) {
+        this.$title.empty();
         this.$list.empty();
         this.$content.empty();
         this.$titleButtons.empty();
@@ -305,14 +306,14 @@ export default class RevisionsDialog extends BasicWidget {
             }
         } else if (revisionItem.type === "code") {
             this.$content.html($("<pre>")
-                .text(fullRevision.content).html());
+                .text(fullRevision.content).prop("outerHTML"));
         } else if (revisionItem.type === "image") {
             if (fullRevision.mime === "image/svg+xml") {
                 let encodedSVG = encodeURIComponent(fullRevision.content); //Base64 of other format images may be embedded in svg
                 this.$content.html($("<img>")
                     .attr("src", `data:${fullRevision.mime};utf8,${encodedSVG}`)
                     .css("max-width", "100%")
-                    .css("max-height", "100%").html());
+                    .css("max-height", "100%").prop("outerHTML"));
             } else {
                 this.$content.html(
                     $("<img>")
@@ -321,7 +322,7 @@ export default class RevisionsDialog extends BasicWidget {
                         .attr("src", `data:${fullRevision.mime};base64,${fullRevision.content}`)
                         .css("max-width", "100%")
                         .css("max-height", "100%")
-                        .html()
+                        .prop("outerHTML")
                 );
             }
         } else if (revisionItem.type === "file") {
@@ -340,7 +341,7 @@ export default class RevisionsDialog extends BasicWidget {
                 );
             }
 
-            this.$content.html($table.html());
+            this.$content.html($table.prop("outerHTML"));
         } else if (["canvas", "mindMap"].includes(revisionItem.type)) {
             const encodedTitle = encodeURIComponent(revisionItem.title);
 
@@ -348,7 +349,7 @@ export default class RevisionsDialog extends BasicWidget {
                 $("<img>")
                     .attr("src", `api/revisions/${revisionItem.revisionId}/image/${encodedTitle}?${Math.random()}`)
                     .css("max-width", "100%")
-                .html());
+                    .prop("outerHTML"));
         } else if (revisionItem.type === "mermaid") {
             const encodedTitle = encodeURIComponent(revisionItem.title);
 
@@ -356,7 +357,7 @@ export default class RevisionsDialog extends BasicWidget {
                 $("<img>")
                     .attr("src", `api/revisions/${revisionItem.revisionId}/image/${encodedTitle}?${Math.random()}`)
                     .css("max-width", "100%")
-                .html());
+                    .prop("outerHTML"));
 
             this.$content.append($("<pre>").text(fullRevision.content));
         } else {


### PR DESCRIPTION
Related to [https://github.com/TriliumNext/trilium/issues/5556], enabling Canvas and Mind Map previews.

The main change is replacing `.html()` with `.prop("outerHTML")`.

Reason: `<img>` is a self-closing tag with no child elements, so `.html()` returns empty, which prevents the preview.

The `.html()` method was introduced during the conversion from `.js` to `.ts`, leading to the bug: https://github.com/TriliumNext/Notes/commit/8f6376e53775db5da6ac2a40c1da505bfa0b927d.