### PR TITLE
fix(build/electron): hotfix for failing nightly electron builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Build your personal knowledge base with TriliumNext Notes",
   "version": "0.92.3-beta",
   "license": "AGPL-3.0-only",
-  "main": "./dist/electron-main.js",
+  "main": "./build/electron-main.js",
   "author": {
     "name": "TriliumNext Notes Team",
     "email": "contact@eliandoran.me",


### PR DESCRIPTION
Hi
this PR fixes the currently failing electron-forge builds.

This is caused by my recent change, where I had to change the output dir of "build:prepare-dist" from "dist" to "build".

-> this is just a temporary fix to fix building again via CI nightly
-> I am working in parallel already on an improved electron-forge build process, which will be ready by end of the week