### PR TITLE
Add {isoMonth} month pattern to day notes

### DIFF
--- a/docs/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.md
+++ b/docs/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.md
@@ -43,7 +43,7 @@ It's possible to customize the title of generated date notes by defining a `#dat
 
 It is also possible to customize the title of generated month notes through the `#monthPattern` attribute, much like `#datePattern`. The options are:
 
-*   `{isoDate}` results in an ISO 8061 formatted month (e.g. "2025-03" for March 2025)
+*   `{isoMonth}` results in an ISO 8061 formatted month (e.g. "2025-03" for March 2025)
 *   `{monthNumberPadded}` results in a number like `09` for September, and `11` for November
 *   `{month}` results in the full month name (e.g. `September` or `October`)
 *   `{shortMonth3}` is replaced with the first 3 letters of the month, e.g. Jan, Feb, etc.

--- a/docs/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.md
+++ b/docs/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.md
@@ -43,6 +43,7 @@ It's possible to customize the title of generated date notes by defining a `#dat
 
 It is also possible to customize the title of generated month notes through the `#monthPattern` attribute, much like `#datePattern`. The options are:
 
+*   `{isoDate}` results in an ISO 8061 formatted month (e.g. "2025-03" for March 2025)
 *   `{monthNumberPadded}` results in a number like `09` for September, and `11` for November
 *   `{month}` results in the full month name (e.g. `September` or `October`)
 *   `{shortMonth3}` is replaced with the first 3 letters of the month, e.g. Jan, Feb, etc.

--- a/src/public/app/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.html
+++ b/src/public/app/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.html
@@ -76,6 +76,8 @@
           the <code>#monthPattern</code> attribute, much like <code>#datePattern</code>.
           The options are:</p>
         <ul>
+          <li><code>{isoMonth}</code> results in an ISO 8061 formatted month (e.g.
+            "2025-03" for March 2025)</li>
           <li><code>{monthNumberPadded}</code> results in a number like <code>09</code> for
             September, and <code>11</code> for November</li>
           <li><code>{month}</code> results in the full month name (e.g. <code>September</code> or <code>October</code>)</li>

--- a/src/services/date_notes.ts
+++ b/src/services/date_notes.ts
@@ -111,6 +111,7 @@ function getMonthNoteTitle(rootNote: BNote, monthNumber: string, dateObj: Date) 
     return pattern
         .replace(/{shortMonth3}/g, monthName.slice(0, 3))
         .replace(/{shortMonth4}/g, monthName.slice(0, 4))
+        .replace(/{isoMonth}/g, dateUtils.utcDateStr(dateObj).slice(0, 7))
         .replace(/{monthNumberPadded}/g, monthNumber)
         .replace(/{month}/g, monthName);
 }


### PR DESCRIPTION
This PR adds the new month pattern ```{isoMonth}```, which is replaced by the ISO 8601 month, such as ```2025-03``` for March 2025.

Trilium automatically creates notes in a year/month/day hierarchy when a new day note is created, typically from the calendar widget. The month note title pattern attribute ```#monthPattern``` defaults to ```{monthNumberPadded} - {month}```. This pattern generates the title "03 - March" for March 2025.

The pattern generates the same title for the month of March in any year. This concise format is easily understood within the context of the note tree, where months appear hierarchically under years (and days under months).

The format is ambiguous when it appears as an internal link within some note text. A reader must mouse over the link to see the full hierarchical path including the year. The problem is more acute when note text contains links to the same month in different years.

The new month pattern ```{isoMonth}``` removes the ambiguity by providing both the year and month numbers. For example, the month pattern  ```{isoMonth} - {month}``` would generate the title "2025-03 - March" for March 2025.

An alternative would be a month pattern for the year. This could be combined with other month patterns to generate any desired combination of year and month designators. For example, ```{month} {year}``` would generate "March 2025" for March 2025. The ```{isoMonth}``` month pattern was chosen instead for consistency with the ```{isoDate}``` day pattern already provided by Trilium.