### PR TITLE
Revert "chore(deps): update apple-actions/import-codesign-certs action to v4"

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -18,7 +18,7 @@ runs:
     # Certificate setup
     - name: Import Apple certificates
       if: inputs.os == 'macos'
-      uses: apple-actions/import-codesign-certs@v4
+      uses: apple-actions/import-codesign-certs@v3
       with:
         p12-file-base64: ${{ env.APPLE_APP_CERTIFICATE_BASE64 }}
         p12-password: ${{ env.APPLE_APP_CERTIFICATE_PASSWORD }}
@@ -27,7 +27,7 @@ runs:
 
     - name: Install Installer certificate
       if: inputs.os == 'macos'
-      uses: apple-actions/import-codesign-certs@v4
+      uses: apple-actions/import-codesign-certs@v3
       with:
         p12-file-base64: ${{ env.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
         p12-password: ${{ env.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
Reverts TriliumNext/Notes#1495

Due to https://github.com/Apple-Actions/import-codesign-certs/issues/69.