### PR TITLE
 To prevent search lag when there are a large number of notes

### DIFF
--- a/src/public/app/services/note_autocomplete.ts
+++ b/src/public/app/services/note_autocomplete.ts
@@ -11,7 +11,8 @@ const SELECTED_NOTE_PATH_KEY = "data-note-path";
 const SELECTED_EXTERNAL_LINK_KEY = "data-external-link";
 
 // To prevent search lag when there are a large number of notes, set a delay based on the number of notes to avoid jitter.
-const notesCount = await server.get<number>(`stats/notesCount`);
+const notesCount = await server.get<number>(`autocomplete/notesCount`);
+console.log(notesCount);
 let debounceTimeoutId: ReturnType<typeof setTimeout>;
 
 function getSearchDelay(notesCount: number): number {

--- a/src/public/app/services/note_autocomplete.ts
+++ b/src/public/app/services/note_autocomplete.ts
@@ -1,6 +1,5 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import utils from "./utils.js";
 import noteCreateService from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
@@ -12,12 +11,11 @@ const SELECTED_EXTERNAL_LINK_KEY = "data-external-link";
 
 // To prevent search lag when there are a large number of notes, set a delay based on the number of notes to avoid jitter.
 const notesCount = await server.get<number>(`autocomplete/notesCount`);
-console.log(notesCount);
 let debounceTimeoutId: ReturnType<typeof setTimeout>;
 
 function getSearchDelay(notesCount: number): number {
-    const maxNotes = 20000; 
-    const maxDelay = 1000;  
+    const maxNotes = 20000;
+    const maxDelay = 1000;
     const delay = Math.min(maxDelay, (notesCount / maxNotes) * maxDelay);
     return delay;
 }
@@ -168,10 +166,10 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
     // Used to track whether the user is performing character composition with an input method (such as Chinese Pinyin, Japanese, Korean, etc.) and to avoid triggering a search during the composition process.
     let isComposingInput = false;
     $el.on("compositionstart", () => {
-        isComposingInput = true; 
+        isComposingInput = true;
     });
     $el.on("compositionend", () => {
-        isComposingInput = false; 
+        isComposingInput = false;
     });
 
     $el.addClass("note-autocomplete-input");
@@ -253,8 +251,8 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                             return;
                         }
                         autocompleteSource(term, cb, options);
-                    }, searchDelay); 
-                    
+                    }, searchDelay);
+
                     if (searchDelay === 0) {
                         searchDelay = getSearchDelay(notesCount);
                     }

--- a/src/routes/api/autocomplete.ts
+++ b/src/routes/api/autocomplete.ts
@@ -8,6 +8,7 @@ import cls from "../../services/cls.js";
 import becca from "../../becca/becca.js";
 import type { Request } from "express";
 import ValidationError from "../../errors/validation_error.js";
+import sql from "../../services/sql.js";
 
 function getAutocomplete(req: Request) {
     if (typeof req.query.query !== "string") {
@@ -79,6 +80,15 @@ function getRecentNotes(activeNoteId: string) {
     });
 }
 
+// Get the total number of notes
+function getNotesCount(req: Request) {
+    const notesCount = sql.getRow(
+        `SELECT COUNT(*) AS count FROM notes WHERE isDeleted = 0;`,
+    ) as { count: number };
+    return notesCount.count;
+}
+
 export default {
-    getAutocomplete
+    getAutocomplete,
+    getNotesCount
 };

--- a/src/routes/api/stats.ts
+++ b/src/routes/api/stats.ts
@@ -48,7 +48,16 @@ function getSubtreeSize(req: Request) {
     };
 }
 
+// Get the total number of notes
+function getNotesCount(req: Request) {
+    const notesCount = sql.getRow(
+        `SELECT COUNT(*) AS count FROM notes WHERE isDeleted = 0;`,
+    ) as { count: number };
+    return notesCount.count;
+}
+
 export default {
     getNoteSize,
-    getSubtreeSize
+    getSubtreeSize,
+    getNotesCount
 };

--- a/src/routes/api/stats.ts
+++ b/src/routes/api/stats.ts
@@ -48,16 +48,7 @@ function getSubtreeSize(req: Request) {
     };
 }
 
-// Get the total number of notes
-function getNotesCount(req: Request) {
-    const notesCount = sql.getRow(
-        `SELECT COUNT(*) AS count FROM notes WHERE isDeleted = 0;`,
-    ) as { count: number };
-    return notesCount.count;
-}
-
 export default {
     getNoteSize,
-    getSubtreeSize,
-    getNotesCount
+    getSubtreeSize
 };

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -361,6 +361,7 @@ function register(app: express.Application) {
     apiRoute(GET, "/api/similar-notes/:noteId", similarNotesRoute.getSimilarNotes);
     apiRoute(GET, "/api/backend-log", backendLogRoute.getBackendLog);
     apiRoute(GET, "/api/stats/note-size/:noteId", statsRoute.getNoteSize);
+    apiRoute(GET, "/api/stats/notesCount", statsRoute.getNotesCount);
     apiRoute(GET, "/api/stats/subtree-size/:noteId", statsRoute.getSubtreeSize);
     apiRoute(PST, "/api/delete-notes-preview", notesApiRoute.getDeleteNotesPreview);
     route(GET, "/api/fonts", [auth.checkApiAuthOrElectron], fontsRoute.getFontCss);

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -273,6 +273,7 @@ function register(app: express.Application) {
     route(PST, "/api/setup/sync-seed", [auth.checkAppNotInitialized], setupApiRoute.saveSyncSeed, apiResultHandler, false);
 
     apiRoute(GET, "/api/autocomplete", autocompleteApiRoute.getAutocomplete);
+    apiRoute(GET, "/api/autocomplete/notesCount", autocompleteApiRoute.getNotesCount);
     apiRoute(GET, "/api/quick-search/:searchString", searchRoute.quickSearch);
     apiRoute(GET, "/api/search-note/:noteId", searchRoute.searchFromNote);
     apiRoute(PST, "/api/search-and-execute-note/:noteId", searchRoute.searchAndExecute);
@@ -361,7 +362,6 @@ function register(app: express.Application) {
     apiRoute(GET, "/api/similar-notes/:noteId", similarNotesRoute.getSimilarNotes);
     apiRoute(GET, "/api/backend-log", backendLogRoute.getBackendLog);
     apiRoute(GET, "/api/stats/note-size/:noteId", statsRoute.getNoteSize);
-    apiRoute(GET, "/api/stats/notesCount", statsRoute.getNotesCount);
     apiRoute(GET, "/api/stats/subtree-size/:noteId", statsRoute.getSubtreeSize);
     apiRoute(PST, "/api/delete-notes-preview", notesApiRoute.getDeleteNotesPreview);
     route(GET, "/api/fonts", [auth.checkApiAuthOrElectron], fontsRoute.getFontCss);


### PR DESCRIPTION
1. https://github.com/TriliumNext/Notes/commit/fd53e35f6fe8a2a82ef8937b7763e9cc9daf9eb3#r154636117
For some languages, such as Chinese, a word may consist of only 1-2 characters, so directly setting a minimum search length might not be applicable to all languages. Therefore, it has been modified to use a delay method to prevent jitter.

2. To avoid triggering a search during character composition.
For example, when the input status of the following figure should not be searched:
![图片](https://github.com/user-attachments/assets/fac72b09-3514-4ce9-8e48-73febdbf1b0d)

