### PR TITLE
fix(electron_context_menu): fix disabled search engine contex menu on readonly notes

### DIFF
--- a/src/public/app/menus/electron_context_menu.ts
+++ b/src/public/app/menus/electron_context_menu.ts
@@ -115,7 +115,6 @@ function setupContextMenu() {
             items.push({ title: "----" });
 
             items.push({
-                enabled: editFlags.canPaste,
                 title: t("electron_context_menu.search_online", { term: shortenedSelection, searchEngine: searchEngineName }),
                 uiIcon: "bx bx-search-alt",
                 handler: () => electron.shell.openExternal(searchUrl)


### PR DESCRIPTION
Hi,

this PR aims to fixes bug described in #543  - it was caused by a  wrong check in the "enabled" prop:
It was previously checking if `canPaste` - which in this context does not make sense.
Here it would only make sense to check for `hasText`, which is already done here https://github.com/TriliumNext/Notes/blob/aa418c49a30d18522b63d4b8b1714d1d2dde452f/src/public/app/menus/electron_context_menu.ts#L96

just need to do a quick build and test properly, before I mark this as ready - will happen later today.

fixes #543 