### PR TITLE
Forced to trigger search after compositionend

### DIFF
--- a/src/public/app/services/note_autocomplete.ts
+++ b/src/public/app/services/note_autocomplete.ts
@@ -170,6 +170,10 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
     });
     $el.on("compositionend", () => {
         isComposingInput = false;
+        const searchString = $el.autocomplete("val") as unknown as string;
+        $el.autocomplete("val", "");
+        $el.setSelectedNotePath("");
+        $el.autocomplete("val", searchString);
     });
 
     $el.addClass("note-autocomplete-input");

--- a/src/public/app/services/note_autocomplete.ts
+++ b/src/public/app/services/note_autocomplete.ts
@@ -172,7 +172,6 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
         isComposingInput = false;
         const searchString = $el.autocomplete("val") as unknown as string;
         $el.autocomplete("val", "");
-        $el.setSelectedNotePath("");
         $el.autocomplete("val", searchString);
     });
 


### PR DESCRIPTION
When the `compositionend` event is triggered, the character composition by the input method has been completed. However, due to the nature of input methods, the final content in the input box does not always trigger a search.  
For example, in Chinese input methods, if you type "Note" and there are no corresponding Chinese candidates, pressing Enter directly will submit "Note." Since the input box content hasn't changed, the search won't be triggered.  
This PR forces the search to be triggered when the `compositionend` event ends.

![图片](https://github.com/user-attachments/assets/5c06403d-9327-4299-b1d4-c8e20d18824d)
