### PR TITLE
chore(format): format .spec files

### DIFF
--- a/src/services/data_dir.spec.ts
+++ b/src/services/data_dir.spec.ts
@@ -64,17 +64,17 @@ describe("data_dir.ts unit tests", async () => {
         type TestCaseGetPlatformAppDataDir = [description: string, fnValue: Parameters<typeof getPlatformAppDataDir>, expectedValue: string | null, osHomedirMockValue: string | null];
 
         const testCases: TestCaseGetPlatformAppDataDir[] = [
-            ["w/ unsupported OS it should return 'null'", ["aix", undefined], null, null],
+            [ "w/ unsupported OS it should return 'null'", [ "aix", undefined ], null, null ],
 
-            ["w/ win32 and no APPDATA set it should return 'null'", ["win32", undefined], null, null],
+            [ "w/ win32 and no APPDATA set it should return 'null'", [ "win32", undefined ], null, null ],
 
-            ["w/ win32 and set APPDATA it should return set 'APPDATA'", ["win32", "AppData"], "AppData", null],
+            [ "w/ win32 and set APPDATA it should return set 'APPDATA'", [ "win32", "AppData" ], "AppData", null ],
 
-            ["w/ linux it should return '~/.local/share'", ["linux", undefined], "/home/mock/.local/share", "/home/mock"],
+            [ "w/ linux it should return '~/.local/share'", [ "linux", undefined ], "/home/mock/.local/share", "/home/mock" ],
 
-            ["w/ linux and wrongly set APPDATA it should ignore APPDATA and return '~/.local/share'", ["linux", "FakeAppData"], "/home/mock/.local/share", "/home/mock"],
+            [ "w/ linux and wrongly set APPDATA it should ignore APPDATA and return '~/.local/share'", [ "linux", "FakeAppData" ], "/home/mock/.local/share", "/home/mock" ],
 
-            ["w/ darwin it should return '~/Library/Application Support'", ["darwin", undefined], "/Users/mock/Library/Application Support", "/Users/mock"]
+            [ "w/ darwin it should return '~/Library/Application Support'", [ "darwin", undefined ], "/Users/mock/Library/Application Support", "/Users/mock" ]
         ];
 
         beforeEach(() => {
@@ -83,7 +83,7 @@ describe("data_dir.ts unit tests", async () => {
         });
 
         testCases.forEach((testCase) => {
-            const [testDescription, fnValues, expected, osHomedirMockValue] = testCase;
+            const [ testDescription, fnValues, expected, osHomedirMockValue ] = testCase;
             return it(testDescription, () => {
                 mockFn.osHomedirMock.mockReturnValue(osHomedirMockValue);
                 const actual = getPlatformAppDataDir(...fnValues);
@@ -272,7 +272,7 @@ describe("data_dir.ts unit tests", async () => {
     });
 
     describe("#getDataDirs()", () => {
-        const envKeys: Omit<keyof ReturnType<typeof getDataDirs>, "TRILIUM_DATA_DIR">[] = ["DOCUMENT_PATH", "BACKUP_DIR", "LOG_DIR", "ANONYMIZED_DB_DIR", "CONFIG_INI_PATH", "TMP_DIR"];
+        const envKeys: Omit<keyof ReturnType<typeof getDataDirs>, "TRILIUM_DATA_DIR">[] = [ "DOCUMENT_PATH", "BACKUP_DIR", "LOG_DIR", "ANONYMIZED_DB_DIR", "CONFIG_INI_PATH", "TMP_DIR" ];
 
         const setMockedEnv = (prefix: string | null) => {
             envKeys.forEach((key) => {

--- a/src/services/in_app_help.spec.ts
+++ b/src/services/in_app_help.spec.ts
@@ -7,7 +7,7 @@ describe("In-app help", () => {
         const meta: NoteMeta = {
             isClone: false,
             noteId: "yoAe4jV2yzbd",
-            notePath: ["OkOZllzB3fqN", "yoAe4jV2yzbd"],
+            notePath: [ "OkOZllzB3fqN", "yoAe4jV2yzbd" ],
             title: "Features",
             notePosition: 40,
             prefix: null,
@@ -38,7 +38,7 @@ describe("In-app help", () => {
         const meta: NoteMeta = {
             isClone: false,
             noteId: "yoAe4jV2yzbd",
-            notePath: ["OkOZllzB3fqN", "yoAe4jV2yzbd"],
+            notePath: [ "OkOZllzB3fqN", "yoAe4jV2yzbd" ],
             title: "Features",
             notePosition: 40,
             prefix: null,

--- a/src/services/sanitize_attribute_name.spec.ts
+++ b/src/services/sanitize_attribute_name.spec.ts
@@ -3,33 +3,33 @@ import sanitizeAttributeName from "./sanitize_attribute_name.js";
 
 // fn value, expected value
 const testCases: [fnValue: string, expectedValue: string][] = [
-    ["testName", "testName"],
-    ["test_name", "test_name"],
-    ["test with space", "test_with_space"],
-    ["test:with:colon", "test:with:colon"],
+    [ "testName", "testName" ],
+    [ "test_name", "test_name" ],
+    [ "test with space", "test_with_space" ],
+    [ "test:with:colon", "test:with:colon" ],
 
     // numbers
-    ["123456", "123456"],
-    ["123:456", "123:456"],
-    ["123456 abc", "123456_abc"],
+    [ "123456", "123456" ],
+    [ "123:456", "123:456" ],
+    [ "123456 abc", "123456_abc" ],
 
     // non-latin characters
-    ["ε", "ε"],
-    ["attribute ε", "attribute_ε"],
+    [ "ε", "ε" ],
+    [ "attribute ε", "attribute_ε" ],
 
     // special characters
-    ["test/name", "test_name"],
-    ["test%name", "test_name"],
-    ["\/", "_"],
+    [ "test/name", "test_name" ],
+    [ "test%name", "test_name" ],
+    [ "\/", "_" ],
 
     // empty string
-    ["", "unnamed"]
+    [ "", "unnamed" ]
 ];
 
 describe("sanitizeAttributeName unit tests", () => {
     testCases.forEach((testCase) => {
         return it(`'${testCase[0]}' should return '${testCase[1]}'`, () => {
-            const [value, expected] = testCase;
+            const [ value, expected ] = testCase;
             const actual = sanitizeAttributeName(value);
             expect(actual).toStrictEqual(expected);
         });

--- a/src/services/tree.spec.ts
+++ b/src/services/tree.spec.ts
@@ -61,7 +61,7 @@ describe("Tree", () => {
             rootNote.child(note(String(i)));
         }
 
-        const expectedOrder = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+        const expectedOrder = [ "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" ];
 
         // Sort a few times to ensure that the resulting order is the same.
         for (let i = 0; i < 5; i++) {

--- a/src/services/utils.spec.ts
+++ b/src/services/utils.spec.ts
@@ -61,17 +61,17 @@ describe.todo("#hash", () => {});
 
 describe("#isEmptyOrWhitespace", () => {
     const testCases: TestCase<typeof utils.isEmptyOrWhitespace>[] = [
-        ["w/ 'null' it should return true", [null], true],
-        ["w/ 'null' it should return true", [null], true],
-        ["w/ undefined it should return true", [undefined], true],
-        ["w/ empty string '' it should return true", [""], true],
-        ["w/ single whitespace string ' ' it should return true", [" "], true],
-        ["w/ multiple whitespace string '   ' it should return true", ["  "], true],
-        ["w/ non-empty string ' t  ' it should return false", [" t  "], false]
+        [ "w/ 'null' it should return true", [ null ], true ],
+        [ "w/ 'null' it should return true", [ null ], true ],
+        [ "w/ undefined it should return true", [ undefined ], true ],
+        [ "w/ empty string '' it should return true", [ "" ], true ],
+        [ "w/ single whitespace string ' ' it should return true", [ " " ], true ],
+        [ "w/ multiple whitespace string '   ' it should return true", [ "  " ], true ],
+        [ "w/ non-empty string ' t  ' it should return false", [ " t  " ], false ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.isEmptyOrWhitespace(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -81,18 +81,18 @@ describe("#isEmptyOrWhitespace", () => {
 
 describe("#sanitizeSqlIdentifier", () => {
     const testCases: TestCase<typeof utils.sanitizeSqlIdentifier>[] = [
-        ["w/ 'test' it should not strip anything", ["test"], "test"],
-        ["w/ 'test123' it should not strip anything", ["test123"], "test123"],
-        ["w/ 'tEst_TeSt' it should not strip anything", ["tEst_TeSt"], "tEst_TeSt"],
-        ["w/ 'test_test' it should not strip '_'", ["test_test"], "test_test"],
-        ["w/ 'test-' it should strip the '-'", ["test-"], "test"],
-        ["w/ 'test-test' it should strip the '-'", ["test-test"], "testtest"],
-        ["w/ 'test; --test' it should strip the '; --'", ["test; --test"], "testtest"],
-        ["w/ 'test test' it should strip the ' '", ["test test"], "testtest"]
+        [ "w/ 'test' it should not strip anything", [ "test" ], "test" ],
+        [ "w/ 'test123' it should not strip anything", [ "test123" ], "test123" ],
+        [ "w/ 'tEst_TeSt' it should not strip anything", [ "tEst_TeSt" ], "tEst_TeSt" ],
+        [ "w/ 'test_test' it should not strip '_'", [ "test_test" ], "test_test" ],
+        [ "w/ 'test-' it should strip the '-'", [ "test-" ], "test" ],
+        [ "w/ 'test-test' it should strip the '-'", [ "test-test" ], "testtest" ],
+        [ "w/ 'test; --test' it should strip the '; --'", [ "test; --test" ], "testtest" ],
+        [ "w/ 'test test' it should strip the ' '", [ "test test" ], "testtest" ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.sanitizeSqlIdentifier(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -120,7 +120,7 @@ describe("#toObject", () => {
             { testPropA: "keyA", testPropB: "valueA" },
             { testPropA: "keyB", testPropB: "valueB" }
         ];
-        const fn: TestListFn = (testListEntry: TestListEntry) => [testListEntry.testPropA + "_fn", testListEntry.testPropB + "_fn"];
+        const fn: TestListFn = (testListEntry: TestListEntry) => [ testListEntry.testPropA + "_fn", testListEntry.testPropB + "_fn" ];
 
         const result = utils.toObject(testList, fn);
         expect(result).toStrictEqual({
@@ -138,13 +138,13 @@ def</p>
 <p>ghi</p>`;
 
     const testCases: TestCase<typeof utils.stripTags>[] = [
-        ["should strip all tags and only return the content, leaving new lines and spaces in tact", [htmlWithNewlines], "abc\ndef\nghi"],
+        [ "should strip all tags and only return the content, leaving new lines and spaces in tact", [ htmlWithNewlines ], "abc\ndef\nghi" ],
         //TriliumNextTODO: should this actually insert a space between content to prevent concatenated text?
-        ["should strip all tags and only return the content", ["<h1>abc</h1><p>def</p>"], "abcdef"]
+        [ "should strip all tags and only return the content", [ "<h1>abc</h1><p>def</p>" ], "abcdef" ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.stripTags(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -162,33 +162,33 @@ describe("#getContentDisposition", () => {
     const testCases: TestCase<typeof utils.getContentDisposition>[] = [
         [
             "when passed filename is empty, it should fallback to default value 'file'",
-            [" "],
+            [ " " ],
             defaultFallBackDisposition
         ],
         [
             "when passed filename '..' would cause sanitized filename to be empty, it should fallback to default value 'file'",
-            [".."],
+            [ ".." ],
             defaultFallBackDisposition
         ],
         // COM1 is a Windows specific "illegal filename" that sanitize filename strips away
         [
             "when passed filename 'COM1' would cause sanitized filename to be empty, it should fallback to default value 'file'",
-            ["COM1"],
+            [ "COM1" ],
             defaultFallBackDisposition
         ],
         [
             "sanitized passed filename should be returned URIEncoded",
-            ["test file.csv"],
+            [ "test file.csv" ],
             `file; filename="test%20file.csv"; filename*=UTF-8''test%20file.csv`
         ]
-    ]
+    ];
 
     testCases.forEach(testCase => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.getContentDisposition(...fnParams);
             expect(result).toStrictEqual(expected);
-        })
+        });
     });
 });
 
@@ -197,38 +197,38 @@ describe("#isStringNote", () => {
     const testCases: TestCase<typeof utils.isStringNote>[] = [
         [
             "w/ 'undefined' note type, but a string mime type, it should return true",
-            [undefined, "application/javascript"],
+            [ undefined, "application/javascript" ],
             true
         ],
         [
             "w/ non-string note type, it should return false",
-            ["image", "image/jpeg"],
+            [ "image", "image/jpeg" ],
             false
         ],
         [
             "w/ string note type (text), it should return true",
-            ["text", "text/html"],
+            [ "text", "text/html" ],
             true
         ],
         [
             "w/ string note type (code), it should return true",
-            ["code", "application/json"],
+            [ "code", "application/json" ],
             true
         ],
         [
             "w/ non-string note type (file), but string mime type, it should return true",
-            ["file", "application/json"],
+            [ "file", "application/json" ],
             true
         ],
         [
             "w/ non-string note type (file), but mime type starting with 'text/', it should return true",
-            ["file", "text/html"],
+            [ "file", "text/html" ],
             true
-        ],
+        ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.isStringNote(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -242,15 +242,15 @@ describe.todo("#replaceAll", () => {});
 
 describe("#removeTextFileExtension", () => {
     const testCases: TestCase<typeof utils.removeTextFileExtension>[] = [
-        ["w/ 'test.md' it should strip '.md'", ["test.md"], "test"],
-        ["w/ 'test.markdown' it should strip '.markdown'", ["test.markdown"], "test"],
-        ["w/ 'test.html' it should strip '.html'", ["test.html"], "test"],
-        ["w/ 'test.htm' it should strip '.htm'", ["test.htm"], "test"],
-        ["w/ 'test.zip' it should NOT strip '.zip'", ["test.zip"], "test.zip"]
+        [ "w/ 'test.md' it should strip '.md'", [ "test.md" ], "test" ],
+        [ "w/ 'test.markdown' it should strip '.markdown'", [ "test.markdown" ], "test" ],
+        [ "w/ 'test.html' it should strip '.html'", [ "test.html" ], "test" ],
+        [ "w/ 'test.htm' it should strip '.htm'", [ "test.htm" ], "test" ],
+        [ "w/ 'test.zip' it should NOT strip '.zip'", [ "test.zip" ], "test.zip" ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.removeTextFileExtension(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -261,63 +261,63 @@ describe("#removeTextFileExtension", () => {
 describe("#getNoteTitle", () => {
     const testCases: TestCase<typeof utils.getNoteTitle>[] = [
         [
-          "when file has no spaces, and no special file extension, it should return the filename unaltered",
-          ["test.json", true, undefined],
-          "test.json"
+            "when file has no spaces, and no special file extension, it should return the filename unaltered",
+            [ "test.json", true, undefined ],
+            "test.json"
         ],
         [
-          "when replaceUnderscoresWithSpaces is false, it should keep the underscores in the title",
-          ["test_file.json", false, undefined],
-          "test_file.json"
+            "when replaceUnderscoresWithSpaces is false, it should keep the underscores in the title",
+            [ "test_file.json", false, undefined ],
+            "test_file.json"
         ],
         [
-          "when replaceUnderscoresWithSpaces is true, it should replace the underscores in the title",
-          ["test_file.json", true, undefined],
-          "test file.json"
+            "when replaceUnderscoresWithSpaces is true, it should replace the underscores in the title",
+            [ "test_file.json", true, undefined ],
+            "test file.json"
         ],
         [
-          "when filePath ends with one of the extra handled endings (.md), it should strip the file extension from the title",
-          ["test_file.md", false, undefined],
-          "test_file"
+            "when filePath ends with one of the extra handled endings (.md), it should strip the file extension from the title",
+            [ "test_file.md", false, undefined ],
+            "test_file"
         ],
         [
-          "when filePath ends with one of the extra handled endings (.md) and replaceUnderscoresWithSpaces is true, it should strip the file extension from the title and replace underscores",
-          ["test_file.md", true, undefined],
-          "test file"
+            "when filePath ends with one of the extra handled endings (.md) and replaceUnderscoresWithSpaces is true, it should strip the file extension from the title and replace underscores",
+            [ "test_file.md", true, undefined ],
+            "test file"
         ],
         [
-          "when filepath contains a full path, it should only return the basename of the file",
-          ["Trilium Demo/Scripting examples/Statistics/Most cloned notes/template.zip", true, undefined],
-          "template.zip"
+            "when filepath contains a full path, it should only return the basename of the file",
+            [ "Trilium Demo/Scripting examples/Statistics/Most cloned notes/template.zip", true, undefined ],
+            "template.zip"
         ],
         [
-          "when filepath contains a full path and has extra handled ending (.html), it should only return the basename of the file and strip the file extension",
-          ["Trilium Demo/Scripting examples/Statistics/Most cloned notes/template.html", true, undefined],
-          "template"
+            "when filepath contains a full path and has extra handled ending (.html), it should only return the basename of the file and strip the file extension",
+            [ "Trilium Demo/Scripting examples/Statistics/Most cloned notes/template.html", true, undefined ],
+            "template"
         ],
         [
-          "when a noteMeta object is passed, it should use the title from the noteMeta, if present",
-          ["test_file.md", true, { title: "some other title"}],
-          "some other title"
-        ],
-        [
-          "when a noteMeta object is passed, but the title prop is empty, it should try to handle the filename as if no noteMeta was passed",
-          ["test_file.md", true, { title: ""}],
-          "test file"
+            "when a noteMeta object is passed, it should use the title from the noteMeta, if present",
+            [ "test_file.md", true, { title: "some other title" } ],
+            "some other title"
         ],
         [
             "when a noteMeta object is passed, but the title prop is empty, it should try to handle the filename as if no noteMeta was passed",
-            ["test_file.json", false, { title: " "}],
+            [ "test_file.md", true, { title: "" } ],
+            "test file"
+        ],
+        [
+            "when a noteMeta object is passed, but the title prop is empty, it should try to handle the filename as if no noteMeta was passed",
+            [ "test_file.json", false, { title: " " } ],
             "test_file.json"
         ]
     ];
 
     testCases.forEach(testCase => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.getNoteTitle(...fnParams);
             expect(result).toStrictEqual(expected);
-          });
+        });
     });
 
 });
@@ -389,15 +389,15 @@ describe("#deferred", () => {
 
 describe("#removeDiacritic", () => {
     const testCases: TestCase<typeof utils.removeDiacritic>[] = [
-        ["w/ 'Äpfel' it should replace the 'Ä'", ["Äpfel"], "Apfel"],
-        ["w/ 'Été' it should replace the 'É' and 'é'", ["Été"], "Ete"],
-        ["w/ 'Fête' it should replace the 'ê'", ["Fête"], "Fete"],
-        ["w/ 'Αλφαβήτα' it should replace the 'ή'", ["Αλφαβήτα"], "Αλφαβητα"],
-        ["w/ '' (empty string) it should return empty string", [""], ""]
+        [ "w/ 'Äpfel' it should replace the 'Ä'", [ "Äpfel" ], "Apfel" ],
+        [ "w/ 'Été' it should replace the 'É' and 'é'", [ "Été" ], "Ete" ],
+        [ "w/ 'Fête' it should replace the 'ê'", [ "Fête" ], "Fete" ],
+        [ "w/ 'Αλφαβήτα' it should replace the 'ή'", [ "Αλφαβήτα" ], "Αλφαβητα" ],
+        [ "w/ '' (empty string) it should return empty string", [ "" ], "" ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.removeDiacritic(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -407,15 +407,15 @@ describe("#removeDiacritic", () => {
 
 describe("#normalize", () => {
     const testCases: TestCase<typeof utils.normalize>[] = [
-        ["w/ 'Äpfel' it should replace the 'Ä' and return lowercased", ["Äpfel"], "apfel"],
-        ["w/ 'Été' it should replace the 'É' and 'é' and return lowercased", ["Été"], "ete"],
-        ["w/ 'FêTe' it should replace the 'ê' and return lowercased", ["FêTe"], "fete"],
-        ["w/ 'ΑλΦαβήΤα' it should replace the 'ή' and return lowercased", ["ΑλΦαβήΤα"], "αλφαβητα"],
-        ["w/ '' (empty string) it should return empty string", [""], ""]
+        [ "w/ 'Äpfel' it should replace the 'Ä' and return lowercased", [ "Äpfel" ], "apfel" ],
+        [ "w/ 'Été' it should replace the 'É' and 'é' and return lowercased", [ "Été" ], "ete" ],
+        [ "w/ 'FêTe' it should replace the 'ê' and return lowercased", [ "FêTe" ], "fete" ],
+        [ "w/ 'ΑλΦαβήΤα' it should replace the 'ή' and return lowercased", [ "ΑλΦαβήΤα" ], "αλφαβητα" ],
+        [ "w/ '' (empty string) it should return empty string", [ "" ], "" ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.normalize(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -425,21 +425,21 @@ describe("#normalize", () => {
 
 describe("#toMap", () => {
     it("should return an instace of Map, with the correct size and keys, when supplied with a list and existing keys", () => {
-        const testList = [{title: "test", propA: "text", propB: 123 }, {title: "test2", propA: "prop2", propB: 456 }];
+        const testList = [ { title: "test", propA: "text", propB: 123 }, { title: "test2", propA: "prop2", propB: 456 } ];
         const result = utils.toMap(testList, "title");
         expect(result).toBeInstanceOf(Map);
         expect(result.size).toBe(2);
-        expect(Array.from(result.keys())).toStrictEqual(["test", "test2"]);
+        expect(Array.from(result.keys())).toStrictEqual([ "test", "test2" ]);
     });
     it("should return an instace of Map, with an empty size, when the supplied list does not contain the supplied key", () => {
-        const testList = [{title: "test", propA: "text", propB: 123 }, {title: "test2", propA: "prop2", propB: 456 }];
+        const testList = [ { title: "test", propA: "text", propB: 123 }, { title: "test2", propA: "prop2", propB: 456 } ];
         //@ts-expect-error - key is non-existing on supplied list type
         const result = utils.toMap(testList, "nonExistingKey");
         expect(result).toBeInstanceOf(Map);
         expect(result.size).toBe(0);
     });
     it.fails("should correctly handle duplicate keys? (currently it will overwrite the entry, so returned size will be 1 instead of 2)", () => {
-        const testList = [{title: "testDupeTitle", propA: "text", propB: 123 }, {title: "testDupeTitle", propA: "prop2", propB: 456 }];
+        const testList = [ { title: "testDupeTitle", propA: "text", propB: 123 }, { title: "testDupeTitle", propA: "prop2", propB: 456 } ];
         const result = utils.toMap(testList, "title");
         expect(result).toBeInstanceOf(Map);
         expect(result.size).toBe(2);
@@ -448,25 +448,25 @@ describe("#toMap", () => {
 
 describe("#envToBoolean", () => {
     const testCases: TestCase<typeof utils.envToBoolean>[] = [
-        ["w/ 'true' it should return boolean 'true'", ["true"], true],
-        ["w/ 'True' it should return boolean 'true'", ["True"], true],
-        ["w/ 'TRUE' it should return boolean 'true'", ["TRUE"], true],
-        ["w/ 'true ' it should return boolean 'true'", ["true "], true],
-        ["w/ 'false' it should return boolean 'false'", ["false"], false],
-        ["w/ 'False' it should return boolean 'false'", ["False"], false],
-        ["w/ 'FALSE' it should return boolean 'false'", ["FALSE"], false],
-        ["w/ 'false ' it should return boolean 'false'", ["false "], false],
-        ["w/ 'whatever' (non-boolean string) it should return undefined", ["whatever"], undefined],
-        ["w/ '-' (non-boolean string) it should return undefined", ["-"], undefined],
-        ["w/ '' (empty string) it should return undefined", [""], undefined],
-        ["w/ ' ' (white space string) it should return undefined", [" "], undefined],
-        ["w/ undefined it should return undefined", [undefined], undefined],
+        [ "w/ 'true' it should return boolean 'true'", [ "true" ], true ],
+        [ "w/ 'True' it should return boolean 'true'", [ "True" ], true ],
+        [ "w/ 'TRUE' it should return boolean 'true'", [ "TRUE" ], true ],
+        [ "w/ 'true ' it should return boolean 'true'", [ "true " ], true ],
+        [ "w/ 'false' it should return boolean 'false'", [ "false" ], false ],
+        [ "w/ 'False' it should return boolean 'false'", [ "False" ], false ],
+        [ "w/ 'FALSE' it should return boolean 'false'", [ "FALSE" ], false ],
+        [ "w/ 'false ' it should return boolean 'false'", [ "false " ], false ],
+        [ "w/ 'whatever' (non-boolean string) it should return undefined", [ "whatever" ], undefined ],
+        [ "w/ '-' (non-boolean string) it should return undefined", [ "-" ], undefined ],
+        [ "w/ '' (empty string) it should return undefined", [ "" ], undefined ],
+        [ "w/ ' ' (white space string) it should return undefined", [ " " ], undefined ],
+        [ "w/ undefined it should return undefined", [ undefined ], undefined ],
         //@ts-expect-error - pass wrong type as param
-        ["w/ number 1 it should return undefined", [1], undefined]
+        [ "w/ number 1 it should return undefined", [ 1 ], undefined ]
     ];
 
     testCases.forEach((testCase) => {
-        const [desc, fnParams, expected] = testCase;
+        const [ desc, fnParams, expected ] = testCase;
         it(desc, () => {
             const result = utils.envToBoolean(...fnParams);
             expect(result).toStrictEqual(expected);
@@ -515,7 +515,7 @@ describe("#safeExtractMessageAndStackFromError", () => {
         expect(actual[0]).toBe("Unknown Error");
         expect(actual[1]).toBeUndefined();
     });
-})
+});
 
 describe("#formatDownloadTitle", () => {
     //prettier-ignore
@@ -523,105 +523,105 @@ describe("#formatDownloadTitle", () => {
 
         // empty fileName tests
         [
-            ["", "text", ""],
+            [ "", "text", "" ],
             "untitled.html"
         ],
         [
-            ["", "canvas", ""],
+            [ "", "canvas", "" ],
             "untitled.json"
         ],
         [
-            ["", null, ""],
+            [ "", null, "" ],
             "untitled"
         ],
 
 
         // json extension from type tests
         [
-            ["test_file", "canvas", ""],
+            [ "test_file", "canvas", "" ],
             "test_file.json"
         ],
         [
-            ["test_file", "relationMap", ""],
+            [ "test_file", "relationMap", "" ],
             "test_file.json"
         ],
         [
-            ["test_file", "search", ""],
+            [ "test_file", "search", "" ],
             "test_file.json"
         ],
 
 
         // extension based on mime type
         [
-            ["test_file", null, "text/csv"],
+            [ "test_file", null, "text/csv" ],
             "test_file.csv"
         ],
         [
-            ["test_file_wo_ext", "image", "image/svg+xml"],
+            [ "test_file_wo_ext", "image", "image/svg+xml" ],
             "test_file_wo_ext.svg"
         ],
         [
-            ["test_file_wo_ext", "file", "application/json"],
+            [ "test_file_wo_ext", "file", "application/json" ],
             "test_file_wo_ext.json"
         ],
         [
-            ["test_file_w_fake_ext.ext", "image", "image/svg+xml"],
+            [ "test_file_w_fake_ext.ext", "image", "image/svg+xml" ],
             "test_file_w_fake_ext.ext.svg"
         ],
         [
-            ["test_file_w_correct_ext.svg", "image", "image/svg+xml"],
+            [ "test_file_w_correct_ext.svg", "image", "image/svg+xml" ],
             "test_file_w_correct_ext.svg"
         ],
         [
-            ["test_file_w_correct_ext.svgz", "image", "image/svg+xml"],
+            [ "test_file_w_correct_ext.svgz", "image", "image/svg+xml" ],
             "test_file_w_correct_ext.svgz"
         ],
         [
-            ["test_file.zip", "file", "application/zip"],
+            [ "test_file.zip", "file", "application/zip" ],
             "test_file.zip"
         ],
         [
-            ["test_file", "file", "application/zip"],
+            [ "test_file", "file", "application/zip" ],
             "test_file.zip"
         ],
 
 
         // application/octet-stream tests
         [
-            ["test_file", "file", "application/octet-stream"],
+            [ "test_file", "file", "application/octet-stream" ],
             "test_file"
         ],
         [
-            ["test_file.zip", "file", "application/octet-stream"],
+            [ "test_file.zip", "file", "application/octet-stream" ],
             "test_file.zip"
         ],
         [
-            ["test_file.unknown", null, "application/octet-stream"],
+            [ "test_file.unknown", null, "application/octet-stream" ],
             "test_file.unknown"
         ],
 
 
         // sanitized filename tests
         [
-            ["test/file", null, "application/octet-stream"],
+            [ "test/file", null, "application/octet-stream" ],
             "testfile"
         ],
         [
-            ["test:file.zip", "file", "application/zip"],
+            [ "test:file.zip", "file", "application/zip" ],
             "testfile.zip"
         ],
         [
-            [":::", "file", "application/zip"],
+            [ ":::", "file", "application/zip" ],
             ".zip"
         ],
         [
-            [":::a", "file", "application/zip"],
+            [ ":::a", "file", "application/zip" ],
             "a.zip"
         ]
     ];
 
     testCases.forEach((testCase) => {
-        const [fnParams, expected] = testCase;
+        const [ fnParams, expected ] = testCase;
         return it(`With args '${JSON.stringify(fnParams)}', it should return '${expected}'`, () => {
             const actual = utils.formatDownloadTitle(...fnParams);
             expect(actual).toStrictEqual(expected);

--- a/src/share/routes.spec.ts
+++ b/src/share/routes.spec.ts
@@ -13,7 +13,7 @@ describe("Share API test", () => {
         initializeTranslations();
         app = (await import("../app.js")).default;
         app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
-            const [errMessage] = safeExtractMessageAndStackFromError(err)
+            const [ errMessage ] = safeExtractMessageAndStackFromError(err);
             if (errMessage.includes("Cannot set headers after they are sent to the client")) {
                 cannotSetHeadersCount++;
             }


### PR DESCRIPTION
Hi,

this PR is just running the formatting rules on the .spec files.
This shouldn't affect any open PRs at all.

One thing I did not do here yet: Fix line-length issues from "@stylistic/max-len" rule