### PR TITLE
Use eslint simple-import-sort plugin to enable auto fix

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 export default tseslint.config(
     eslint.configs.recommended,
@@ -17,6 +18,11 @@ export default tseslint.config(
         }
     },
     {
+        plugins: {
+            "simple-import-sort": simpleImportSort
+        }
+    },
+    {
         rules: {
             // add rule overrides here
             "no-undef": "off",
@@ -28,7 +34,8 @@ export default tseslint.config(
                     varsIgnorePattern: "^_"
                 }
             ],
-            "sort-imports": [ "error", { ignoreCase: false } ]
+            "simple-import-sort/imports": "error",
+            "simple-import-sort/exports": "error"
         }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
         "css-loader": "7.1.2",
         "electron": "35.1.4",
         "eslint": "9.24.0",
+        "eslint-plugin-simple-import-sort": "12.1.1",
         "esm": "3.2.25",
         "globals": "16.0.0",
         "happy-dom": "17.4.4",
@@ -10658,6 +10659,16 @@
       "resolved": "https://registry.npmjs.org/eslint-linter-browserify/-/eslint-linter-browserify-9.24.0.tgz",
       "integrity": "sha512-h+y3gq15Hb+7o6VyN/zzkERvfmoAx+wO3l1UJwteCWYPUav0Ffp36j9sb8ZjTi78/nInx7xUHBUYhOT+9xxDMA==",
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "css-loader": "7.1.2",
     "electron": "35.1.4",
     "eslint": "9.24.0",
+    "eslint-plugin-simple-import-sort": "12.1.1",
     "esm": "3.2.25",
     "globals": "16.0.0",
     "happy-dom": "17.4.4",


### PR DESCRIPTION
Use simple-import-sort plugin to enable auto-fix import sort
