### PR TITLE
types: use type variable for sql.transactional's return value

### DIFF
--- a/src/routes/api/recovery_codes.ts
+++ b/src/routes/api/recovery_codes.ts
@@ -47,7 +47,7 @@ function getUsedRecoveryCodes() {
 
     recoveryCodes.forEach((recoveryKey: string) => {
         if (dateRegex.test(recoveryKey)) usedStatus.push(recoveryKey);
-        else usedStatus.push(recoveryCodes.indexOf(recoveryKey));
+        else usedStatus.push(String(recoveryCodes.indexOf(recoveryKey)));
     });
 
     return {

--- a/src/routes/api/recovery_codes.ts
+++ b/src/routes/api/recovery_codes.ts
@@ -43,12 +43,10 @@ function getUsedRecoveryCodes() {
 
     const dateRegex = RegExp(/^\d{4}\/\d{2}\/\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/gm);
     const recoveryCodes = recovery_codes.getRecoveryCodes();
-    const usedStatus: string[] = [];
 
-    recoveryCodes.forEach((recoveryKey: string) => {
-        if (dateRegex.test(recoveryKey)) usedStatus.push(recoveryKey);
-        else usedStatus.push(String(recoveryCodes.indexOf(recoveryKey)));
-    });
+    const usedStatus = recoveryCodes.map(recoveryKey => {
+        return (dateRegex.test(recoveryKey)) ? recoveryKey : String(recoveryCodes.indexOf(recoveryKey))
+    })
 
     return {
         success: true,

--- a/src/services/encryption/recovery_codes.ts
+++ b/src/services/encryption/recovery_codes.ts
@@ -27,7 +27,7 @@ function getRecoveryCodes() {
         return []
     }
 
-    return sql.transactional(() => {
+    return sql.transactional<string[]>(() => {
         const iv = Buffer.from(optionService.getOption('recoveryCodeInitialVector'), 'hex');
         const securityKey = Buffer.from(optionService.getOption('recoveryCodeSecurityKey'), 'hex');
         const encryptedRecoveryCodes = optionService.getOption('recoveryCodesEncrypted');
@@ -41,7 +41,7 @@ function getRecoveryCodes() {
 }
 
 function removeRecoveryCode(usedCode: string) {
-    const oldCodes: string[] = getRecoveryCodes();
+    const oldCodes = getRecoveryCodes();
     const today = new Date();
     oldCodes[oldCodes.indexOf(usedCode)] = today.toJSON().replace(/-/g, '/');
     setRecoveryCodes(oldCodes.toString());
@@ -55,7 +55,7 @@ function verifyRecoveryCode(recoveryCodeGuess: string) {
 
     const recoveryCodes = getRecoveryCodes();
     let loginSuccess = false;
-    recoveryCodes.forEach((recoveryCode: string) => {
+    recoveryCodes.forEach((recoveryCode) => {
         if (recoveryCodeGuess === recoveryCode) {
             removeRecoveryCode(recoveryCode);
             loginSuccess = true;

--- a/src/services/sql.ts
+++ b/src/services/sql.ts
@@ -278,7 +278,7 @@ function transactional<T>(func: (statement: Statement) => T) {
             ws.sendTransactionEntityChangesToAllClients();
         }
 
-        return ret;
+        return ret as T;
     } catch (e) {
         console.warn("Got error ", e);
         const entityChangeIds = cls.getAndClearEntityChangeIds();


### PR DESCRIPTION
Explicitly cast return value as type variable T, so that it gets used.

Previously the type variable was useless, because
the returned variable `const ret = (dbConnection.transaction(func) as any).deferred();` was inferred as "any" by TS, so "T" was never really used.