### PR TITLE
fix(auth): avoid "Error: Option 'redirectBareDomain' doesn't exist" on new installations

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -39,7 +39,9 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
         res.redirect('login');
         return;
     } else if (!req.session.loggedIn && !noAuthentication) {
-        const redirectToShare = options.getOptionBool("redirectBareDomain");
+
+        const redirectToShare = hasRedirectBareDomain();
+
         if (redirectToShare) {
             // Check if any note has the #shareRoot label
             const shareRootNotes = attributes.getNotesWithLabel("shareRoot");
@@ -51,6 +53,18 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
         res.redirect(redirectToShare ? "share" : "login");
     } else {
         next();
+    }
+}
+
+
+// avoid receiving an error, on a new installation, when the DB is not initialized yet
+// => getOptionBool uses getOption, which throws an error if the option name is not found
+// TriliumNextTODO: potentially refactor getOptionBool instead
+function hasRedirectBareDomain() {
+    try {
+        return options.getOptionBool("redirectBareDomain");
+    } catch(e) {
+        return false;
     }
 }
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -40,9 +40,11 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
         return;
     } else if (!req.session.loggedIn && !noAuthentication) {
 
-        const redirectToShare = hasRedirectBareDomain();
+        // cannot use options.getOptionBool currently => it will throw an error on new installations
+        // TriliumNextTODO: look into potentially creating an getOptionBoolOrNull instead
+        const hasRedirectBareDomain = options.getOptionOrNull("redirectBareDomain") === "true";
 
-        if (redirectToShare) {
+        if (hasRedirectBareDomain) {
             // Check if any note has the #shareRoot label
             const shareRootNotes = attributes.getNotesWithLabel("shareRoot");
             if (shareRootNotes.length === 0) {
@@ -50,23 +52,13 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
                 return;
             }
         }
-        res.redirect(redirectToShare ? "share" : "login");
+        res.redirect(hasRedirectBareDomain ? "share" : "login");
     } else {
         next();
     }
 }
 
 
-// avoid receiving an error, on a new installation, when the DB is not initialized yet
-// => getOptionBool uses getOption, which throws an error if the option name is not found
-// TriliumNextTODO: potentially refactor getOptionBool instead
-function hasRedirectBareDomain() {
-    try {
-        return options.getOptionBool("redirectBareDomain");
-    } catch(e) {
-        return false;
-    }
-}
 
 // for electron things which need network stuff
 //  currently, we're doing that for file upload because handling form data seems to be difficult


### PR DESCRIPTION

fixes #1667