### PR TITLE
fix(login): send back 401 Unauthorized on failed login attempt

### DIFF
--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -134,7 +134,7 @@ function sendLoginError(req: Request, res: Response, errorType: 'password' | 'to
         log.info(`WARNING: Wrong password from ${req.ip}, rejecting.`);
     }
 
-    res.render('login', {
+    res.status(401).render('login', {
         wrongPassword: errorType === 'password',
         wrongTotp: errorType === 'totp',
         totpEnabled: totp.isTotpEnabled(),


### PR DESCRIPTION
send back 401 on failed login, same as we did before TOTP:
https://github.com/TriliumNext/Notes/blob/62706a6af2a7ffa3c7411e5ecbd9ce865ecc6049/src/routes/login.ts#L67

closes #1707 