### PR TITLE
Support Bearer Authentication

### DIFF
--- a/src/services/etapi_tokens.ts
+++ b/src/services/etapi_tokens.ts
@@ -48,6 +48,11 @@ function parseAuthToken(auth: string | undefined) {
         auth = basicAuthChunks[1];
     }
 
+    if (auth.startsWith("Bearer ")) {
+        // allow also bearer auth format
+        auth = auth.substring(7);
+    }
+
     const chunks = auth.split("_");
 
     if (chunks.length === 1) {


### PR DESCRIPTION
This PR adds Bearer authentication for ETAPI and solves #1701.

With ETAPI token, now you can use perform REST calls:

```
GET https://myserver.com/etapi/app-info
Authorization: Bearer ETAPITOKEN
```
This is equivalent to

```
GET https://myserver.com/etapi/app-info
Authorization: ETAPITOKEN
```