### PR TITLE
Allow setting CORS headers

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -25,6 +25,11 @@ keyPath=
 # expressjs shortcuts are supported: loopback(127.0.0.1/8, ::1/128), linklocal(169.254.0.0/16, fe80::/10), uniquelocal(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7)
 trustedReverseProxy=false
 
+# setting the CORS headers for cross-origin requests
+# corsAllowOrigin='*'
+# corsAllowMethods='GET,POST,PUT,DELETE,PATCH'
+# corsAllowHeaders='Content-Type,Authorization'
+
 
 [Session]
 # Use this setting to set a custom value for the "Max-Age" Attribute of the session cookie.

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import compression from "compression";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 import sessionParser from "./routes/session_parser.js";
+import config from "./services/config.js";
 import utils from "./services/utils.js";
 import assets from "./routes/assets.js";
 import routes from "./routes/routes.js";
@@ -33,6 +34,17 @@ app.set("views", path.join(scriptDir, "views"));
 app.set("view engine", "ejs");
 
 app.use((req, res, next) => {
+    // set CORS header
+    if (config["Network"]["corsAllowOrigin"].length > 0) {
+        res.header("Access-Control-Allow-Origin", config["Network"]["corsAllowOrigin"]);
+    }
+    if (config["Network"]["corsAllowMethods"].length > 0) {
+        res.header("Access-Control-Allow-Methods", config["Network"]["corsAllowMethods"]);
+    }
+    if (config["Network"]["corsAllowHeaders"].length > 0) {
+        res.header("Access-Control-Allow-Headers", config["Network"]["corsAllowHeaders"]);
+    }
+
     res.locals.t = t;
     return next();
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,13 +35,13 @@ app.set("view engine", "ejs");
 
 app.use((req, res, next) => {
     // set CORS header
-    if (config["Network"]["corsAllowOrigin"].length > 0) {
+    if (config["Network"]["corsAllowOrigin"]) {
         res.header("Access-Control-Allow-Origin", config["Network"]["corsAllowOrigin"]);
     }
-    if (config["Network"]["corsAllowMethods"].length > 0) {
+    if (config["Network"]["corsAllowMethods"]) {
         res.header("Access-Control-Allow-Methods", config["Network"]["corsAllowMethods"]);
     }
-    if (config["Network"]["corsAllowHeaders"].length > 0) {
+    if (config["Network"]["corsAllowHeaders"]) {
         res.header("Access-Control-Allow-Headers", config["Network"]["corsAllowHeaders"]);
     }
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -85,13 +85,13 @@ const config: TriliumConfig = {
             process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy || false,
 
         corsAllowOrigin:
-            process.env.TRILIUM_CORS_ALLOW_ORIGIN || iniConfig.Network.corsAllowOrigin || "",
+            process.env.TRILIUM_NETWORK_CORS_ALLOW_ORIGIN || iniConfig.Network.corsAllowOrigin || "",
 
         corsAllowMethods:
-            process.env.TRILIUM_CORS_ALLOW_METHODS || iniConfig.Network.corsAllowMethods || "",
+            process.env.TRILIUM_NETWORK_CORS_ALLOW_METHODS || iniConfig.Network.corsAllowMethods || "",
 
         corsAllowHeaders:
-            process.env.TRILIUM_CORS_ALLOW_HEADERS || iniConfig.Network.corsAllowHeaders || ""
+            process.env.TRILIUM_NETWORK_CORS_ALLOW_HEADERS || iniConfig.Network.corsAllowHeaders || ""
     },
 
     Session: {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -29,6 +29,9 @@ export interface TriliumConfig {
         certPath: string;
         keyPath: string;
         trustedReverseProxy: boolean | string;
+        corsAllowOrigin: string;
+        corsAllowMethods: string;
+        corsAllowHeaders: string;
     };
     Session: {
         cookieMaxAge: number;
@@ -79,7 +82,16 @@ const config: TriliumConfig = {
             process.env.TRILIUM_NETWORK_KEYPATH || iniConfig.Network.keyPath || "",
 
         trustedReverseProxy:
-            process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy || false
+            process.env.TRILIUM_NETWORK_TRUSTEDREVERSEPROXY || iniConfig.Network.trustedReverseProxy || false,
+
+        corsAllowOrigin:
+            process.env.TRILIUM_CORS_ALLOW_ORIGIN || iniConfig.Network.corsAllowOrigin || "",
+
+        corsAllowMethods:
+            process.env.TRILIUM_CORS_ALLOW_METHODS || iniConfig.Network.corsAllowMethods || "",
+
+        corsAllowHeaders:
+            process.env.TRILIUM_CORS_ALLOW_HEADERS || iniConfig.Network.corsAllowHeaders || ""
     },
 
     Session: {


### PR DESCRIPTION
This PR allows setting CORS headers:

* `Access-Control-Allow-Origin`: by setting environment variable `TRILIUM_NETWORK_CORS_ALLOW_ORIGIN`, or `corsAllowOrigin` in `Network` section in `config.ini`.
* `Access-Control-Allow-Methods`: by setting environment variable `TRILIUM_NETWORK_CORS_ALLOW_METHODS`, or `corsAllowMethods` in `Network` section in `config.ini`.
* `Access-Control-Allow-Headers`: by setting environment variable `TRILIUM_NETWORK_CORS_ALLOW_HEADERS`, or `corsAllowHeaders` in `Network` section in `config.ini`.

For web browser, due to security reason, it doesn't allow other origins to access Trilium server, e.g., Open WebUI. Modifying these headers will avoid this restriction.

By default, I leave these values empty.

Closes TriliumNext/trilium#5664