### PR TITLE
Make each part of the note path clickable.

### DIFF
--- a/src/public/app/services/link.ts
+++ b/src/public/app/services/link.ts
@@ -278,15 +278,20 @@ function goToLinkExt(evt: MouseEvent | JQuery.ClickEvent | JQuery.MouseDownEvent
     const { notePath, viewScope } = parseNavigationStateFromUrl(hrefLink);
 
     const ctrlKey = utils.isCtrlKey(evt);
+    const shiftKey = evt.shiftKey;
     const isLeftClick = "which" in evt && evt.which === 1;
     const isMiddleClick = "which" in evt && evt.which === 2;
     const targetIsBlank = ($link?.attr("target") === "_blank");
     const openInNewTab = (isLeftClick && ctrlKey) || isMiddleClick || targetIsBlank;
+    const activate = (isLeftClick && ctrlKey && shiftKey) || (isMiddleClick && shiftKey);
+    const openInNewWindow = isLeftClick && evt.shiftKey && !ctrlKey;
 
     if (notePath) {
-        if (openInNewTab) {
+        if (openInNewWindow) {
+            appContext.triggerCommand("openInWindow", { notePath, viewScope });
+        } else if (openInNewTab) {
             appContext.tabManager.openTabWithNoteWithHoisting(notePath, {
-                activate: evt.shiftKey ? true : targetIsBlank,
+                activate: activate ? true : targetIsBlank,
                 viewScope
             });
         } else if (isLeftClick) {

--- a/src/public/app/services/link.ts
+++ b/src/public/app/services/link.ts
@@ -286,7 +286,7 @@ function goToLinkExt(evt: MouseEvent | JQuery.ClickEvent | JQuery.MouseDownEvent
     if (notePath) {
         if (openInNewTab) {
             appContext.tabManager.openTabWithNoteWithHoisting(notePath, {
-                activate: targetIsBlank,
+                activate: evt.shiftKey ? true : targetIsBlank,
                 viewScope
             });
         } else if (isLeftClick) {

--- a/src/public/app/widgets/ribbon_widgets/note_paths.ts
+++ b/src/public/app/widgets/ribbon_widgets/note_paths.ts
@@ -19,15 +19,15 @@ const TPL = /*html*/`
         margin-top: 10px;
     }
 
-    .note-path-list .path-current {
+    .note-path-list .path-current a {
         font-weight: bold;
     }
 
-    .note-path-list .path-archived {
+    .note-path-list .path-archived a {
         color: var(--muted-text-color) !important;
     }
 
-    .note-path-list .path-search {
+    .note-path-list .path-search a {
         font-style: italic;
     }
     </style>
@@ -72,7 +72,7 @@ export default class NotePathsWidget extends NoteContextAwareWidget {
         this.$notePathList.empty();
 
         if (!this.note || this.noteId === "root") {
-            this.$notePathList.empty().append(await this.getRenderedPath("root"));
+            this.$notePathList.empty().append(await this.getRenderedPath(["root"]));
 
             return;
         }
@@ -88,7 +88,7 @@ export default class NotePathsWidget extends NoteContextAwareWidget {
         const renderedPaths = [];
 
         for (const notePathRecord of sortedNotePaths) {
-            const notePath = notePathRecord.notePath.join("/");
+            const notePath = notePathRecord.notePath;
 
             renderedPaths.push(await this.getRenderedPath(notePath, notePathRecord));
         }
@@ -96,42 +96,54 @@ export default class NotePathsWidget extends NoteContextAwareWidget {
         this.$notePathList.empty().append(...renderedPaths);
     }
 
-    async getRenderedPath(notePath: string, notePathRecord: NotePathRecord | null = null) {
-        const title = await treeService.getNotePathTitle(notePath);
+    async getRenderedPath(notePath: string[], notePathRecord: NotePathRecord | null = null) {
+        const $pathItem = $("<li>");
+        const pathSegments: string[] = [];
+        const lastIndex = notePath.length - 1;
+        
+        for (let i = 0; i < notePath.length; i++) {
+            const noteId = notePath[i];
+            pathSegments.push(noteId);
+            const title = await treeService.getNoteTitle(noteId);
+            const $noteLink = await linkService.createLink(pathSegments.join("/"), { title });
 
-        const $noteLink = await linkService.createLink(notePath, { title });
-
-        $noteLink.find("a").addClass("no-tooltip-preview tn-link");
+            $noteLink.find("a").addClass("no-tooltip-preview tn-link");
+            $pathItem.append($noteLink);
+            
+            if (i != lastIndex) {
+                $pathItem.append(" / ");
+            }
+        }
 
         const icons = [];
 
-        if (this.notePath === notePath) {
-            $noteLink.addClass("path-current");
+        if (this.notePath === notePath.join("/")) {
+            $pathItem.addClass("path-current");
         }
 
         if (!notePathRecord || notePathRecord.isInHoistedSubTree) {
-            $noteLink.addClass("path-in-hoisted-subtree");
+            $pathItem.addClass("path-in-hoisted-subtree");
         } else {
             icons.push(`<span class="bx bx-trending-up" title="${t("note_paths.outside_hoisted")}"></span>`);
         }
 
         if (notePathRecord?.isArchived) {
-            $noteLink.addClass("path-archived");
+            $pathItem.addClass("path-archived");
 
             icons.push(`<span class="bx bx-archive" title="${t("note_paths.archived")}"></span>`);
         }
 
         if (notePathRecord?.isSearch) {
-            $noteLink.addClass("path-search");
+            $pathItem.addClass("path-search");
 
             icons.push(`<span class="bx bx-search" title="${t("note_paths.search")}"></span>`);
         }
 
         if (icons.length > 0) {
-            $noteLink.append(` ${icons.join(" ")}`);
+            $pathItem.append(` ${icons.join(" ")}`);
         }
 
-        return $("<li>").append($noteLink);
+        return $pathItem;
     }
 
     entitiesReloadedEvent({ loadResults }: EventData<"entitiesReloaded">) {


### PR DESCRIPTION
1. Make each part of the note path in the ribbon clickable, allowing users to navigate to parent notes via the ribbon. Also fixed the issue where its CSS was not applied correctly.  
  before:
  ![图片](https://github.com/user-attachments/assets/7ef3deeb-f2d6-4572-8a6d-b7857e1d044f)
  after:
  ![图片](https://github.com/user-attachments/assets/79aedaf3-8fb8-4ffa-aaf3-f16e3998367b)


2. Enable Ctrl + Shift + Click to open a note in a new tab and activate it, aligning the interaction with Firefox and Edge behavior.