### PR TITLE
fix(calendar): make it once again possible to show more than one `diplayedAttributes` at a time.

### DIFF
--- a/src/public/app/widgets/view_widgets/calendar_view.ts
+++ b/src/public/app/widgets/view_widgets/calendar_view.ts
@@ -186,7 +186,7 @@ export default class CalendarView extends ViewMode {
                 if (promotedAttributes) {
                     let promotedAttributesHtml = "";
                     for (const [name, value] of promotedAttributes) {
-                        promotedAttributesHtml = /*html*/`\
+                        promotedAttributesHtml = promotedAttributesHtml + /*html*/`\
                         <div class="promoted-attribute">
                             <span class="promoted-attribute-name">${name}</span>: <span class="promoted-attribute-value">${value}</span>
                         </div>`;


### PR DESCRIPTION
Fixes TriliumNext/trilium#5680