### PR TITLE
feat: support custom oidc server

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -55,3 +55,16 @@ oauthClientId=
 # Set the client secret for OAuth/OpenID authentication
 # This is the secret of the client that will be used to verify the user's identity
 oauthClientSecret=
+
+# Set the base URL for the OpenID Connect issuer
+# Default value is "https://accounts.google.com"
+issuerBaseUrl=
+
+# Set the name of the OpenID Connect issuer
+# This name will be displayed on the login (/login) interface.
+# Default value is "Google"
+issuerName=
+
+# Set the URL of the icon for the OpenID Connect issuer
+# This icon will be displayed on the login (/login) interface.
+issuerIcon=

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -18,6 +18,8 @@ function loginPage(req: Request, res: Response) {
         wrongTotp: false,
         totpEnabled: totp.isTotpEnabled(),
         ssoEnabled: openID.isOpenIDEnabled(),
+        ssoName: openID.getSsoName(),
+        ssoIcon: openID.getSsoIcon(),
         assetPath: assetPath,
         appPath: appPath,
     });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -45,6 +45,9 @@ export interface TriliumConfig {
         oauthBaseUrl: string;
         oauthClientId: string;
         oauthClientSecret: string;
+        issuerBaseUrl: string;
+        issuerName: string;
+        issuerIcon: string;
     };
 }
 
@@ -119,7 +122,16 @@ const config: TriliumConfig = {
             process.env.TRILIUM_OAUTH_CLIENT_ID || iniConfig?.MultiFactorAuthentication?.oauthClientId || "",
 
         oauthClientSecret:
-            process.env.TRILIUM_OAUTH_CLIENT_SECRET || iniConfig?.MultiFactorAuthentication?.oauthClientSecret || ""
+            process.env.TRILIUM_OAUTH_CLIENT_SECRET || iniConfig?.MultiFactorAuthentication?.oauthClientSecret || "",
+
+        issuerBaseUrl:
+            process.env.TRILIUM_ISSUER_BASE_URL || iniConfig?.MultiFactorAuthentication?.issuerBaseUrl || "https://accounts.google.com",
+
+        issuerName:
+            process.env.TRILIUM_ISSUER_NAME || iniConfig?.MultiFactorAuthentication?.issuerName || "Google",
+
+        issuerIcon:
+            process.env.TRILIUM_ISSUER_ICON || iniConfig?.MultiFactorAuthentication?.issuerIcon || ""
     }
 };
 

--- a/src/services/open_id.ts
+++ b/src/services/open_id.ts
@@ -89,6 +89,14 @@ function isTokenValid(req: Request, res: Response, next: NextFunction) {
     }
 }
 
+function getSsoName() {
+    return config.MultiFactorAuthentication.issuerName
+}
+
+function getSsoIcon() {
+    return config.MultiFactorAuthentication.issuerIcon
+}
+
 function generateOAuthConfig() {
     const authRoutes = {
         callback: "/callback",
@@ -105,7 +113,7 @@ function generateOAuthConfig() {
         auth0Logout: false,
         baseURL: config.MultiFactorAuthentication.oauthBaseUrl,
         clientID: config.MultiFactorAuthentication.oauthClientId,
-        issuerBaseURL: "https://accounts.google.com",
+        issuerBaseURL: config.MultiFactorAuthentication.issuerBaseUrl,
         secret: config.MultiFactorAuthentication.oauthClientSecret,
         clientSecret: config.MultiFactorAuthentication.oauthClientSecret,
         authorizationParams: {
@@ -128,8 +136,9 @@ function generateOAuthConfig() {
 
             openIDEncryption.saveUser(
                 req.oidc.user.sub.toString(),
-                req.oidc.user.name.toString(),
-                req.oidc.user.email.toString()
+                // The claims of the ID token do not include name and email by default.
+                req.oidc.user.name?.toString() || "none",
+                req.oidc.user.email?.toString() || "none"
             );
 
             req.session.loggedIn = true;
@@ -148,6 +157,8 @@ export default {
     generateOAuthConfig,
     getOAuthStatus,
     isOpenIDEnabled,
+    getSsoName,
+    getSsoIcon,
     clearSavedUser,
     isTokenValid,
     isUserSaved,

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -26,8 +26,8 @@
 
         <% if (ssoEnabled) { %>
             <a href="/authenticate" class="google-login-btn">
-                <img src="<%= assetPath %>/images/google-logo.svg" alt="Google logo">
-                <%= t("login.sign_in_with_google") %>
+                <img src="<%= ssoIcon.length === 0 ? assetPath + '/images/google-logo.svg' : ssoIcon %>" alt="<%= ssoName %>">
+                <%= t("login.sign_in_with_sso", { ssoName }) %>
             </a>
         <% } else { %>
             <form action="login" method="POST">

--- a/translations/cn/server.json
+++ b/translations/cn/server.json
@@ -103,7 +103,7 @@
     "password": "密码",
     "remember-me": "记住我",
     "button": "登录",
-    "sign_in_with_google": "使用 Google 登录"
+    "sign_in_with_sso": "使用 {{ ssoName }} 登录"
   },
   "set_password": {
     "title": "设置密码",

--- a/translations/en/server.json
+++ b/translations/en/server.json
@@ -103,7 +103,7 @@
     "password": "Password",
     "remember-me": "Remember me",
     "button": "Login",
-    "sign_in_with_google": "Sign in with Google"
+    "sign_in_with_sso": "Sign in with {{ ssoName }}"
   },
   "set_password": {
     "title": "Set Password",


### PR DESCRIPTION
This PR allows setting a custom OIDC server.
Three fields have been added to `MultiFactorAuthentication`:
 - `issuerBaseUrl`: Set the base URL for the OpenID Connect issuer.
 - `issuerName`: Set the name of the OpenID Connect issuer.
 - `issuerIcon`: Set the URL of the icon for the OpenID Connect issuer.

This has been tested with `Authelia`, and if the fields are left empty, it defaults to Google OIDC.

![image](https://github.com/user-attachments/assets/1b9d0b4a-2ddf-4f10-8dfd-6c742e5d0f7e)
