### PR TITLE
Fix incorrect import of multiple inline math.

### DIFF
--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1222,10 +1222,6 @@ body:not(.mobile) #launcher-pane.horizontal .dropdown-submenu > .dropdown-menu {
     background-color: inherit;
 }
 
-::selection {
-    background-color: #3399FF70;
-}
-
 [data-bs-toggle="tooltip"]:not(.button-widget) span {
     padding-bottom: 0;
     border-bottom: 1px dotted;

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1222,6 +1222,10 @@ body:not(.mobile) #launcher-pane.horizontal .dropdown-submenu > .dropdown-menu {
     background-color: inherit;
 }
 
+::selection {
+    background-color: #3399FF70;
+}
+
 [data-bs-toggle="tooltip"]:not(.button-widget) span {
     padding-bottom: 0;
     border-bottom: 1px dotted;

--- a/apps/server/src/services/import/markdown.spec.ts
+++ b/apps/server/src/services/import/markdown.spec.ts
@@ -188,6 +188,12 @@ second line 2</code></pre><ul><li>Hello</li><li>world</li></ul><ol><li>Hello</li
         expect(markdownService.renderToHtml(input, "Title")).toStrictEqual(expected);
     });
 
+    it("converts multiple inline math expressions into Mathtex format", () => {
+        const input = `Energy: $e=mc^{2}$, Force: $F=ma$.`;
+        const expected = /*html*/`<p>Energy: <span class="math-tex">\\(e=mc^{2}\\)</span>, Force: <span class="math-tex">\\(F=ma\\)</span>.</p>`;
+        expect(markdownService.renderToHtml(input, "Title")).toStrictEqual(expected);
+    });
+
     it("converts display math expressions into Mathtex format", () => {
         const input = `$$\sqrt{x^{2}+1}$$`;
         const expected = /*html*/`<p><span class="math-tex">\\[\sqrt{x^{2}+1}\\]</span></p>`;

--- a/apps/server/src/services/import/markdown.ts
+++ b/apps/server/src/services/import/markdown.ts
@@ -25,7 +25,7 @@ class CustomMarkdownRenderer extends Renderer {
                 `<span class="math-tex">\\\[$1\\\]</span>`);
 
             // Inline math
-            text = text.replaceAll(/(?<!\\)\$(.+)\$/g,
+            text = text.replaceAll(/(?<!\\)\$(.+?)\$/g,
                 `<span class="math-tex">\\\($1\\\)</span>`);
         }
 


### PR DESCRIPTION
Fix the issue where multiple formulas on a single line are incorrectly treated as one when importing Markdown from the clipboard.

A test case:
```
The fundamental idea underpinning the GKAT architecture is the observation that the attention matrix $A_i$ from GAT can be "densified" as follows:

$$A_i(k, l) = \frac{K(q_k, k_l) T(k, l)}{\sum\limits_{r \in V} K(q_k, k_r) T(k, r)} \tag{2}$$

where $K : \mathbb{R}^d \times \mathbb{R}^d \rightarrow \mathbb{R}$ is a kernel defined on feature vectors in nodes of the graph and $T : V \times V \rightarrow \mathbb{R}$ is another kernel defined on the nodes of the graph $G$ (that for simplicity will depend only on the topology of the graph, but not feature vectors in those nodes).
```