### PR TITLE
Some css fine tunes

### DIFF
--- a/apps/client/src/services/note_tooltip.ts
+++ b/apps/client/src/services/note_tooltip.ts
@@ -176,7 +176,25 @@ function renderFootnote($link: JQuery<HTMLElement>, url: string) {
         .closest(".footnote-item") // find the parent container of the footnote
         .find(".footnote-content"); // find the actual text content of the footnote
 
-    return $footnoteContent.html() || "";
+    const isEditable = $link.closest(".ck-content").hasClass("note-detail-editable-text-editor");
+    if (isEditable) {
+        /* Remove widget buttons for tables, formulas, and images in editable notes. */
+        $footnoteContent.find('.ck-widget__selection-handle').remove();
+        $footnoteContent.find('.ck-widget__type-around').remove();
+        $footnoteContent.find('.ck-widget__resizer').remove();
+
+        /* Handling in-line math formulas */
+        $footnoteContent.find('.ck-math-tex.ck-math-tex-inline.ck-widget').each(function () {
+            const $katex = $(this).find('.katex, .katex-display').first();
+            if ($katex.length) {
+                $(this).replaceWith($('<span class="math-tex"></span>').append($('<span></span>').append($katex.clone())));
+            }
+        });
+    }
+    
+    let footnoteContent = $footnoteContent.html();
+    footnoteContent = `<div class="ck-content">${footnoteContent}</div>`
+    return footnoteContent || "";
 }
 
 export default {

--- a/apps/client/src/services/note_tooltip.ts
+++ b/apps/client/src/services/note_tooltip.ts
@@ -10,6 +10,7 @@ import { t } from "./i18n.js";
 
 // Track all elements that open tooltips
 let openTooltipElements: JQuery<HTMLElement>[] = [];
+let dismissTimer: ReturnType<typeof setTimeout>;
 
 function setupGlobalTooltip() {
     $(document).on("mouseenter", "a", mouseEnterHandler);
@@ -26,6 +27,7 @@ function setupGlobalTooltip() {
 }
 
 function dismissAllTooltips() {
+    clearTimeout(dismissTimer);
     openTooltipElements.forEach($el => {
         $el.tooltip("dispose");
         $el.removeAttr("aria-describedby");
@@ -129,11 +131,11 @@ async function mouseEnterHandler(this: HTMLElement) {
                 // cursor is neither over the link nor over the tooltip, user likely is not interested
                 dismissAllTooltips();
             } else {
-                setTimeout(checkTooltip, 1000);
+                dismissTimer = setTimeout(checkTooltip, 1000);
             }
         };
 
-        setTimeout(checkTooltip, 1000);
+        dismissTimer = setTimeout(checkTooltip, 1000);
     }
 }
 

--- a/apps/client/src/services/note_tooltip.ts
+++ b/apps/client/src/services/note_tooltip.ts
@@ -185,7 +185,7 @@ function renderFootnote($link: JQuery<HTMLElement>, url: string) {
 
         /* Handling in-line math formulas */
         $footnoteContent.find('.ck-math-tex.ck-math-tex-inline.ck-widget').each(function () {
-            const $katex = $(this).find('.katex, .katex-display').first();
+            const $katex = $(this).find('.katex').first();
             if ($katex.length) {
                 $(this).replaceWith($('<span class="math-tex"></span>').append($('<span></span>').append($katex.clone())));
             }

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1222,6 +1222,10 @@ body:not(.mobile) #launcher-pane.horizontal .dropdown-submenu > .dropdown-menu {
     background-color: inherit;
 }
 
+::selection {
+    background-color: var(--selection-background-color);
+}
+
 [data-bs-toggle="tooltip"]:not(.button-widget) span {
     padding-bottom: 0;
     border-bottom: 1px dotted;

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1782,7 +1782,7 @@ body.zen .title-row {
     height: unset !important;
     -webkit-app-region: drag;
     padding-left: env(titlebar-area-x);
-    padding-right: 2.5em;
+    padding-right: calc(100vw - env(titlebar-area-width, 100vw) + 2.5em);
 }
 
 body.zen .floating-buttons {

--- a/apps/client/src/stylesheets/theme-next-dark.css
+++ b/apps/client/src/stylesheets/theme-next-dark.css
@@ -195,6 +195,8 @@
     --scrollbar-background-color: transparent;
     --scrollbar-border-color: unset; /* Deprecated */
 
+    --selection-background-color: #3399FF70;
+    
     --link-color: lightskyblue;
 
     --mermaid-theme: dark;

--- a/apps/client/src/stylesheets/theme-next-light.css
+++ b/apps/client/src/stylesheets/theme-next-light.css
@@ -194,6 +194,8 @@
     --scrollbar-background-color: transparent;
     --scrollbar-border-color: unset; /* Deprecated */
 
+    --selection-background-color: #3399FF70;
+
     --link-color: blue;
 
     --mermaid-theme: default;

--- a/apps/client/src/stylesheets/theme-next/shell.css
+++ b/apps/client/src/stylesheets/theme-next/shell.css
@@ -131,6 +131,7 @@ body.layout-horizontal > .horizontal {
 }
 
 #launcher-pane.vertical #launcher-container {
+    width: var(--launcher-pane-size);
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;

--- a/packages/ckeditor5-footnotes/theme/footnote.css
+++ b/packages/ckeditor5-footnotes/theme/footnote.css
@@ -44,10 +44,9 @@
 	flex-grow: 1;
 }
 
-.ck .ck-widget.footnote-section .ck-widget__type-around__button_after {
-	display:none; /* hides the 'insert after' button from the ckeditor widget */
+.ck .ck-widget.footnote-section > .ck-reset_all.ck-widget__type-around > .ck-widget__type-around__button_after {
+	display: none; /* hides the 'insert after' button from the ckeditor widget, but displays the button inside the footnote content. */
 }
-
 .placeholder {
 	padding: 2px 2px;
 	outline-offset: -2px;


### PR DESCRIPTION
1. Original Text:
![Image](https://github.com/user-attachments/assets/523b139e-cf15-41b2-9ad5-22ce0a490ec9)

   Original Selection Style:
![Image](https://github.com/user-attachments/assets/89883d97-7778-4cbc-a016-44298eab8e27)

   Adjusted Selection Style:
![Image](https://github.com/user-attachments/assets/59a820f8-57e7-4948-a60f-b74edb4a0752)

2. When collapsing the left pane, the button shifts due to the border of the launcher pane.

3. In Zen mode, long titles can overlap and block the buttons.
![图片](https://github.com/user-attachments/assets/15049939-e216-4c95-831b-f8c28b46b681)

4. Previously, formulas in footnote did not have an after arrow
![图片](https://github.com/user-attachments/assets/b7b5ee2d-f317-4e96-be97-127ca48c1683)
    Therefore, it was modified:
![图片](https://github.com/user-attachments/assets/f9457f55-12b7-4f21-b914-418a90bb820b)

5. [fix misaligned display in footnote tooltip](https://github.com/TriliumNext/Notes/pull/1913/commits/6cb27279a08fb38ae47707f2638babb48762f683)
Previously：
![图片](https://github.com/user-attachments/assets/57a5d9cd-a9a0-4bb9-b777-60ab9bc1447c)
After:
![图片](https://github.com/user-attachments/assets/712ca4d9-dd11-4ed6-b215-6b51979a2360)

6. [fix(tooltip): Sometimes tooltip flashes](https://github.com/TriliumNext/Notes/pull/1913/commits/5ce0383c03953e19735aaf13898f171a8514868f)
   Steps to reproduce the issue:
Move the mouse over the link (<a>), and the tooltip appears.
Then move the mouse out of the link, and move it back in again — the tooltip flickers once.