### PR TITLE
fix(global_menu): Fix update button is blank

### DIFF
--- a/apps/client/src/widgets/buttons/global_menu.ts
+++ b/apps/client/src/widgets/buttons/global_menu.ts
@@ -405,6 +405,7 @@ export default class GlobalMenuWidget extends BasicWidget {
     }
 
     async updateVersionStatus() {
+        this.$updateToLatestVersionButton.toggle(false);
         await options.initializedPromise;
 
         if (options.get("checkForUpdates") !== "true") {


### PR DESCRIPTION
For the next theme, when there is no network or updates are disabled, the update button appears blank. Here, set it to hidden by default during initialization.

![图片](https://github.com/user-attachments/assets/604af996-8e3e-497c-b7ad-5015d0afcf87)
