### PR TITLE
 fix(global_menu): Fix update button is blank

### DIFF
--- a/apps/client/src/widgets/buttons/global_menu.ts
+++ b/apps/client/src/widgets/buttons/global_menu.ts
@@ -231,7 +231,7 @@ const TPL = /*html*/`
             ${t("global_menu.about")}
         </li>
 
-        <li class="dropdown-item update-to-latest-version-button" style="display:none" data-trigger-command="downloadLatestVersion">
+        <li class="dropdown-item update-to-latest-version-button" style="display: none" data-trigger-command="downloadLatestVersion">
             <span class="bx bx-sync"></span>
 
             <span class="version-text"></span>

--- a/apps/client/src/widgets/buttons/global_menu.ts
+++ b/apps/client/src/widgets/buttons/global_menu.ts
@@ -53,10 +53,6 @@ const TPL = /*html*/`
         pointer-events: none;
     }
 
-    .update-to-latest-version-button {
-        display: none;
-    }
-
     .global-menu .zoom-container {
         display: flex;
         flex-direction: row;
@@ -235,7 +231,7 @@ const TPL = /*html*/`
             ${t("global_menu.about")}
         </li>
 
-        <li class="dropdown-item update-to-latest-version-button" data-trigger-command="downloadLatestVersion">
+        <li class="dropdown-item update-to-latest-version-button" style="display:none" data-trigger-command="downloadLatestVersion">
             <span class="bx bx-sync"></span>
 
             <span class="version-text"></span>

--- a/apps/client/src/widgets/buttons/global_menu.ts
+++ b/apps/client/src/widgets/buttons/global_menu.ts
@@ -231,7 +231,7 @@ const TPL = /*html*/`
             ${t("global_menu.about")}
         </li>
 
-        <li class="dropdown-item update-to-latest-version-button" style="display: none" data-trigger-command="downloadLatestVersion">
+        <li class="dropdown-item update-to-latest-version-button" style="display: none;" data-trigger-command="downloadLatestVersion">
             <span class="bx bx-sync"></span>
 
             <span class="version-text"></span>


### PR DESCRIPTION
For the next theme, when there is no network or updates are disabled, the update button appears blank. Here, like the global-menu-button-update-available, directly set the CSS for the update-to-latest-version-button to be initially hidden inline.
![445082776-604af996-8e3e-497c-b7ad-5015d0afcf87](https://github.com/user-attachments/assets/a0fbdf34-fecd-4489-aac1-e48a05fa104e)
