### PR TITLE
fix: improve tab scroll UX by switching from instant to smooth behavior

### DIFF
--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -473,7 +473,7 @@ export default class TabRowWidget extends BasicWidget {
         const totalTabsWidthUsingTarget = flooredClampedTargetWidth * numberOfTabs + marginWidth;
         const totalExtraWidthDueToFlooring = tabsContainerWidth - totalTabsWidthUsingTarget;
 
-        const widths = [];
+        const widths: number[] = [];
         let extraWidthRemaining = totalExtraWidthDueToFlooring;
 
         for (let i = 0; i < numberOfTabs; i += 1) {

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -386,15 +386,8 @@ export default class TabRowWidget extends BasicWidget {
     };
 
     setupScrollEvents() {
-        let isScrolling = false;
         this.$tabScrollingContainer[0].addEventListener('wheel', (event) => {
-            if (!isScrolling) {
-                isScrolling = true;
-                requestAnimationFrame(() => {
-                    this.scrollTabContainer(event.deltaY * 1.5, 'instant');
-                    isScrolling = false;
-                });
-            }
+            this.scrollTabContainer(event.deltaY * 1.5);
         });
 
         this.$scrollButtonLeft[0].addEventListener('click', () => this.scrollTabContainer(-200));


### PR DESCRIPTION
Previously, when using `scrollTo({ behavior: 'instant' })` to scroll the tab container, the scroll action felt too abrupt and fast. Users could not visually perceive where the scroll originated or ended.

Replaced the `instant` scroll behavior with `smooth`.