### PR TITLE
feat(tab-row): Added smooth decay logic

### DIFF
--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -399,8 +399,8 @@ export default class TabRowWidget extends BasicWidget {
                 isScrolling = false;
             }
         };
-        this.$tabScrollingContainer[0].addEventListener('wheel', (event) => {
-            if (!event.shiftKey || event.deltaX === 0) {
+        this.$tabScrollingContainer[0].addEventListener('wheel', async (event) => {
+            if (!event.shiftKey && event.deltaX === 0) {
                 event.preventDefault();
                 // Clamp deltaX between TAB_CONTAINER_MIN_WIDTH and TAB_CONTAINER_MIN_WIDTH * 3
                 deltaX += Math.sign(event.deltaY) * Math.max(Math.min(Math.abs(event.deltaY), TAB_CONTAINER_MIN_WIDTH * 3), TAB_CONTAINER_MIN_WIDTH);
@@ -408,6 +408,14 @@ export default class TabRowWidget extends BasicWidget {
                     isScrolling = true;
                     stepScroll();
                 }
+            } else if (event.shiftKey) {
+                event.preventDefault();
+                if (event.deltaY > 0) {
+                    await appContext.tabManager.activateNextTabCommand();
+                } else {
+                    await appContext.tabManager.activatePreviousTabCommand();
+                }
+                this.activeTabEl.scrollIntoView();
             }
         });
 


### PR DESCRIPTION
1. To prevent the scroll distance from being too small, clamp it within an upper and lower bound — between TAB_CONTAINER_MIN_WIDTH and TAB_CONTAINER_MIN_WIDTH * 3.

    Previously, using smooth directly could result in the next scroll event being triggered before the previous smooth scroll had completed during rapid scrolling.

2. feat: enable Shift + Wheel to switch tabs (consistent with VSCode behavior)