### PR TITLE
fix(theme): theme is not enabled on the phone

### DIFF
--- a/apps/server/src/assets/views/mobile.ejs
+++ b/apps/server/src/assets/views/mobile.ejs
@@ -118,6 +118,15 @@
 <% if (themeCssUrl) { %>
     <link href="<%= themeCssUrl %>" rel="stylesheet">
 <% } %>
+
+<% if (themeUseNextAsBase === "next") { %>
+  <link href="<%= assetPath %>/stylesheets/theme-next.css" rel="stylesheet">
+<% } else if (themeUseNextAsBase === "next-dark") { %>
+  <link href="<%= assetPath %>/stylesheets/theme-next-dark.css" rel="stylesheet">
+<% } else if (themeUseNextAsBase === "next-light") { %>
+  <link href="<%= assetPath %>/stylesheets/theme-next-light.css" rel="stylesheet">
+<% } %>
+
 <link href="<%= assetPath %>/stylesheets/style.css" rel="stylesheet">
 <link href="<%= assetPath %>/stylesheets/print.css" rel="stylesheet" media="print">
 


### PR DESCRIPTION
When using next as the base for custom themes, theme is not enabled on the phone