### PR TITLE
Tab row scroll

### DIFF
--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -396,8 +396,8 @@ export default class TabRowWidget extends BasicWidget {
             event.currentTarget.scrollLeft += wheelEvent.deltaY + wheelEvent.deltaX;
         });
 
-        this.$scrollButtonLeft[0].addEventListener('click', () => this.scrollTabContainer(-200));
-        this.$scrollButtonRight[0].addEventListener('click', () => this.scrollTabContainer(200));
+        this.$scrollButtonLeft[0].addEventListener('click', () => this.scrollTabContainer(-210));
+        this.$scrollButtonRight[0].addEventListener('click', () => this.scrollTabContainer(210));
 
         this.$tabScrollingContainer[0].addEventListener('scroll', () => {
             clearTimeout(this.updateScrollTimeout);
@@ -729,7 +729,7 @@ export default class TabRowWidget extends BasicWidget {
 
                 const scorllContainerBounds = this.$tabScrollingContainer[0]?.getBoundingClientRect();
                 const pointerX = pointer.pageX;
-                const scrollSpeed = 100; // The increment of each scroll.
+                const scrollSpeed = 105; // The increment of each scroll.
                 // Check if the mouse is near the edge of the container and trigger scrolling.
                 if (pointerX < scorllContainerBounds.left) {
                     this.scrollTabContainer(- scrollSpeed);

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -392,6 +392,7 @@ export default class TabRowWidget extends BasicWidget {
                 return;
             }
             event.preventDefault();
+            event.stopImmediatePropagation();
             event.currentTarget.scrollLeft += wheelEvent.deltaY + wheelEvent.deltaX;
         });
 

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -285,6 +285,7 @@ const TAB_ROW_TPL = `
         overflow-y: hidden;
         scrollbar-width: none; /* Firefox */
     }
+
     /* Chrome/Safari */
     .tab-row-widget-scrolling-container::-webkit-scrollbar {
         display: none;
@@ -391,11 +392,7 @@ export default class TabRowWidget extends BasicWidget {
                 return;
             }
             event.preventDefault();
-
-            const delta = Math.sign(wheelEvent.deltaX + wheelEvent.deltaY) *
-                Math.min(Math.abs(wheelEvent.deltaX + wheelEvent.deltaY), TAB_CONTAINER_MIN_WIDTH * 2);
-
-            this.scrollTabContainer(delta, "instant");
+            event.currentTarget.scrollLeft += wheelEvent.deltaY + wheelEvent.deltaX;
         });
 
         this.$scrollButtonLeft[0].addEventListener('click', () => this.scrollTabContainer(-200));


### PR DESCRIPTION
Use the method from [https://github.com/TriliumNext/Notes/pull/2088](https://github.com/TriliumNext/Notes/pull/2088).

It's possible that some computers can indeed achieve smooth scrolling.
It's unclear whether the issue is device-specific. Not sure if it's an issue with my device.

Listening with jquery.  For users who cannot enable smooth scrolling this way, the listener can be removed in the widget, and smooth scrolling can be implemented via a custom widget instead.

If this method provides smooth scrolling, it's best to test it in both Firefox and Edge (Chromium), as using `scrollTo` for smooth scrolling previously caused frame stuttering in Edge.
