### PR TITLE
chore(editor): relocate link icon in floating toolbar

### DIFF
--- a/apps/client/src/widgets/type_widgets/ckeditor/config.ts
+++ b/apps/client/src/widgets/type_widgets/ckeditor/config.ts
@@ -246,7 +246,7 @@ export function buildFloatingToolbar() {
             {
                 label: "Insert",
                 icon: "plus",
-                items: ["bookmark", "internallink", "includeNote", "|", "math", "mermaid", "horizontalLine", "pageBreak", "dateTime"]
+                items: ["link", "bookmark", "internallink", "includeNote", "|", "math", "mermaid", "horizontalLine", "pageBreak", "dateTime"]
             },
             "|",
             "outdent",


### PR DESCRIPTION
The bookmark is in the floating toolbar, so it seems the link should be there as well.

 In the past, whenever trying to insert a link, the instinct was always to look there and then realize it wasn’t included.
