### PR TITLE
feat(autoformat-math): add \( support and remove line-boundary restrictions for delimiters

### DIFF
--- a/packages/ckeditor5-math/src/autoformatmath.ts
+++ b/packages/ckeditor5-math/src/autoformatmath.ts
@@ -4,6 +4,8 @@ import Math from './math.js';
 import MathCommand from './mathcommand.js';
 import MathUI from './mathui.js';
 
+import type Autoformat from '@ckeditor/ckeditor5-autoformat/src/autoformat';
+
 export default class AutoformatMath extends Plugin {
 	public static get requires() {
 		return [ Math, 'Autoformat' ] as const;
@@ -44,10 +46,22 @@ export default class AutoformatMath extends Plugin {
 				);
 			};
 
-			// @ts-expect-error: blockAutoformatEditing expects an Autoformat instance even though it works with any Plugin instance
-			blockAutoformatEditing( editor, this, /^\$\$$/, callback );
-			// @ts-expect-error: blockAutoformatEditing expects an Autoformat instance even though it works with any Plugin instance
-			blockAutoformatEditing( editor, this, /^\\\[$/, callback );
+			// Common LaTeX math delimiters: \(\), \[\], $$
+			// Chosen based on MathJax defaults:
+			// https://docs.mathjax.org/en/latest/input/tex/delimiters.html
+			//
+			// INFO: blockAutoformatEditing expects an Autoformat instance,
+			// but works fine with any Plugin that has `isEnabled`.
+			// We cast `this` accordingly.
+			// Source: Only `plugin.isEnabled` is used internally in the function:
+			// https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-autoformat/src/blockautoformatediting.ts#L91
+
+			blockAutoformatEditing(
+				editor, this as unknown as Autoformat, /\$\$/, callback );
+			blockAutoformatEditing(
+				editor, this as unknown as Autoformat, /\\\(/, callback );
+			blockAutoformatEditing(
+				editor, this as unknown as Autoformat, /\\\[/, callback );
 		}
 	}
 


### PR DESCRIPTION
This PR improves math autoformat behavior by:

- Adding support for the `\(` inline delimiter  
- Removing start- and end-of-line (`^...$`) restriction for all delimiters  
- Using standard LaTeX-style patterns: `$$`, `\(`, and `\[`[^1]  
- Replacing `@ts-expect-error` with a safe type cast  
- Casting to `Autoformat` is safe — only `.isEnabled` is accessed[^3]  

The original regexes were introduced during a TypeScript refactor[^2], likely as a second thought, and were anchored to match only when the delimiter appeared on its own line. No additional logic or guardrails suggest that this restriction was intentional.

As there are no known edge cases tied to those anchors, and as this feature is used heavily in inline contexts, lifting the restriction makes the behavior more intuitive and consistent with common LaTeX and MathJax environments.

[^1]: MathJax Delimiters – https://docs.mathjax.org/en/latest/input/tex/delimiters.html  
[^2]: Introduced in [commit 9765abc](https://github.com/isaul32/ckeditor5-math/commit/9765abc0bd111bf758eda7485b78eb4a8dff8f9a#diff-9355dd2d54c444214800e2a79d190d1a06d0aac17bf67a21e42b6076d3c39ab7R50) as part of a TypeScript migration.  
To verify, open https://github.com/isaul32/ckeditor5-math and run: `git log -S 'blockAutoformatEditing' -- src/autoformatmath.ts` `git show 9765abc | grep blockAutoformatEditing`

[^3]: See [`blockAutoformatEditing()` source](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-autoformat/src/blockautoformatediting.ts#L91) — only `plugin.isEnabled` is used.
