### PR TITLE
fix(image): ensure images opened in a new tab can be activated

### DIFF
--- a/apps/client/src/widgets/type_widgets/abstract_text_type_widget.ts
+++ b/apps/client/src/widgets/type_widgets/abstract_text_type_widget.ts
@@ -17,6 +17,7 @@ export default class AbstractTextTypeWidget extends TypeWidget {
         this.$widget.on("dblclick", "img", (e) => this.openImageInCurrentTab($(e.target)));
 
         this.$widget.on("click", "img", (e) => {
+            e.stopPropagation();
             const isLeftClick = e.which === 1;
             const isMiddleClick = e.which === 2;
             const ctrlKey = utils.isCtrlKey(e);


### PR DESCRIPTION
Before:

In text notes, the first `Ctrl+Shift+Click` on an image correctly opens the image in a new tab and activates it.
However, after switching back to the original tab, a second `Ctrl+Shift+Click` also opens the image in a new tab, but fails to activate it.

This issue occurs because the click event propagates to the following handler in `apps/client/src/widgets/containers/split_note_container.ts`:

```ts
$renderedWidget.on("click", () => appContext.tabManager.activateNoteContext(noteContext.ntxId));
```

As a result, after the image tab is activated, it is immediately switched back to the original tab, making it appear as though the image tab was not activated.